### PR TITLE
json compare with jq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,4 +74,7 @@ jobs:
       - setup
       - run:
           name: "compare committed corpus with one built with lotus next"
-          command: make compare-with-lotus-next
+          command: make REPO=lotus BRANCH=a0c0d9c98aae compare-corpus
+      - run:
+          name: "compare committed corpus with one built with specs-actors next"
+          command: make REPO=specs-actors BRANCH=master compare-corpus

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,20 @@ executors:
 
 workflows:
   version: 2
-  main:
+  commit:
     jobs:
       - build-and-generate
+      - compare
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - compare
 
 jobs:
   build-and-generate:
@@ -57,3 +68,10 @@ jobs:
       - run:
           name: "validate vectors against JSON Schema"
           command: make validate
+  compare:
+    executor: linux
+    steps:
+      - setup
+      - run:
+          name: "compare committed corpus with one built with lotus next"
+          command: make compare-with-lotus-next

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ GENCOMMIT = `git rev-list -1 HEAD`
 gen:
 	find gen/suites -maxdepth 1 -mindepth 1 -type d -print0 | xargs -I '{}' -n1 -0 bash -c 'dir="$$(basename {})" && echo "=== $${dir} ===" && cd {} && go run -ldflags "-X github.com/filecoin-project/test-vectors/gen/builders.GenscriptCommit=${GENCOMMIT}" . -o "../../../corpus/$${dir}"'
 
-compare-with-lotus-next:
-	pushd gen && go get github.com/filecoin-project/specs-actors@master && go get github.com/filecoin-project/lotus@a0c0d9c98aae && popd && cp -R corpus corpus-current && make gen && mv corpus corpus-new && ./diff.sh
+compare-corpus:
+	./diff.sh ${REPO} ${BRANCH}
 
 validate:
 	cd ./validate && go run ./main.go

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ GENCOMMIT = `git rev-list -1 HEAD`
 gen:
 	find gen/suites -maxdepth 1 -mindepth 1 -type d -print0 | xargs -I '{}' -n1 -0 bash -c 'dir="$$(basename {})" && echo "=== $${dir} ===" && cd {} && go run -ldflags "-X github.com/filecoin-project/test-vectors/gen/builders.GenscriptCommit=${GENCOMMIT}" . -o "../../../corpus/$${dir}"'
 
-
+compare-with-lotus-next:
+	pushd gen && go get github.com/filecoin-project/specs-actors@master && go get github.com/filecoin-project/lotus@a0c0d9c98aae && popd && cp -R corpus corpus-current && make gen && mv corpus corpus-new && ./diff.sh
 
 validate:
 	cd ./validate && go run ./main.go

--- a/diff.sh
+++ b/diff.sh
@@ -1,5 +1,37 @@
 #!/bin/bash
 
+set -o errexit
+set -o pipefail
+set -e
+
+REPO=$1
+BRANCH=$2
+
+# Validate required arguments
+if [ -z "$REPO" ]; then
+  echo -e "Please provider REPO input variable. For example: \`./diff.sh lotus next\`"
+  exit 2
+fi
+if [ -z "$BRANCH" ]; then
+  echo -e "Please provider BRANCH input variable. For example: \`./diff.sh lotus next\`"
+  exit 2
+fi
+
+pushd gen
+go get github.com/filecoin-project/${REPO}@${BRANCH}
+popd
+
+tmp_dir=$(mktemp -d -t ci-compare-corpus-XXXX)
+echo "temporary dir: $tmp_dir"
+
+cp -R corpus corpus-current
+cp -R corpus-current $tmp_dir/corpus-current
+make gen
+mv corpus $tmp_dir/corpus-new
+mv corpus-current corpus
+
+pushd $tmp_dir
+
 # Update in-place all newly generated JSON corpus files and remove the "_meta" field.
 for f in $(find ./corpus-new -type f); do
   echo "$(jq 'del(._meta)' $f)" > $f;
@@ -12,3 +44,7 @@ done
 
 # Run diff between the old and the new test vectors
 diff -qr corpus-new/ corpus-current/
+
+popd
+
+rm -rf $tmp_dir

--- a/diff.sh
+++ b/diff.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Update in-place all newly generated JSON corpus files and remove the "_meta" field.
+for f in $(find ./corpus-new -type f); do
+  echo "$(jq 'del(._meta)' $f)" > $f;
+done
+
+# Update in-place all existing JSON corpus files and remove the "_meta" field.
+for f in $(find ./corpus-current -type f); do
+  echo "$(jq 'del(._meta)' $f)" > $f;
+done
+
+# Run diff between the old and the new test vectors
+diff -qr corpus-new/ corpus-current/


### PR DESCRIPTION
This PR is adding a draft diff functionality with `jq` where we ignore the `_meta` field.

---

TODO:
- [ ] update `go get` to fetch `@next` for Lotus (or specs-actors) once the conformance PR is merged.
- [ ] schedule a CircleCI cron to periodically run `make compare-with-lotus-next`
- [ ] report jobs outcomes to Slack