### PR TITLE
fix: do not run for pushes that update vectors

### DIFF
--- a/.github/workflows/generate-test-vectors.yaml
+++ b/.github/workflows/generate-test-vectors.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - corpus/**/*.json
 jobs:
   update-vectors:
     name: Update test vectors


### PR DESCRIPTION
When a PR is merged that the github action created it will trigger another run, which will effectively be a noop after a bunch of work is done to figure out nothing changed.

This PR mitigates that issue by only running the github action when files are changed outside of the `corpus/` directory.

resolves #67