### PR TITLE
update schema to hold randomness entries and syscall results.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -186,6 +186,37 @@
         },
         "epoch": {
           "type": "integer"
+        },
+        "syscalls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/syscall"
+          }
+        }
+      }
+    },
+    "randomness": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/base64"
+      }
+    },
+    "syscall": {
+      "type": "object",
+      "required": [
+        "name",
+        "is_error"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "is_error": {
+          "type": "boolean"
+        },
+        "error_msg": {
+          "type": "string"
         }
       }
     }
@@ -248,6 +279,9 @@
     },
     "postconditions": {
       "$ref": "#/definitions/postconditions"
+    },
+    "randomness": {
+      "$ref": "#/definitions/randomness"
     }
   },
   "allOf": [

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -132,15 +132,23 @@ type TestVector struct {
 	// objects.
 	CAR Base64EncodedBytes `json:"car"`
 
-	Pre           *Preconditions  `json:"preconditions"`
-	ApplyMessages []Message       `json:"apply_messages"`
-	Post          *Postconditions `json:"postconditions"`
-	Diagnostics   *Diagnostics    `json:"diagnostics"`
+	Pre           *Preconditions            `json:"preconditions"`
+	ApplyMessages []Message                 `json:"apply_messages"`
+	Randomness    map[abi.ChainEpoch][]byte `json:"randomness,omitempty"`
+	Post          *Postconditions           `json:"postconditions"`
+	Diagnostics   *Diagnostics              `json:"diagnostics"`
 }
 
 type Message struct {
-	Bytes Base64EncodedBytes `json:"bytes"`
-	Epoch *abi.ChainEpoch    `json:"epoch,omitempty"`
+	Bytes    Base64EncodedBytes `json:"bytes"`
+	Epoch    *abi.ChainEpoch    `json:"epoch,omitempty"`
+	Syscalls []Syscall          `json:"syscalls,omitempty"`
+}
+
+type Syscall struct {
+	Name     string `json:"name"`
+	IsError  bool   `json:"is_error"`
+	ErrorMsg string `json:"error_msg,omitempty"`
 }
 
 // Validate validates this test vector against the JSON schema, and applies


### PR DESCRIPTION
(1/3)

This extends the test-vector schema to allow messages to optionally list syscalls and expected return status, along with defined random values to respond when queried.

Once defined, the lotus driver in the pending 'conformance' PR can be extended to return these values when provided, then tests can begin populating the fields.