### PR TITLE
feat: improved exit code output format

### DIFF
--- a/gen/builders/predicates.go
+++ b/gen/builders/predicates.go
@@ -31,7 +31,7 @@ func ExitCode(expect exitcode.ExitCode) ApplyRetPredicate {
 		if ret.ExitCode == expect {
 			return nil
 		}
-		return fmt.Errorf("message exit code was %d; expected %d", ret.ExitCode, expect)
+		return fmt.Errorf("message exit code was %s; expected %s", ret.ExitCode, expect)
 	}
 }
 


### PR DESCRIPTION
Prints exit code name as well as number.

Before:

<img width="693" alt="Screenshot 2020-09-01 at 11 11 12" src="https://user-images.githubusercontent.com/152863/91837682-3a674880-ec44-11ea-88ed-c3c3d578fbec.png">

After:

<img width="866" alt="Screenshot 2020-09-01 at 11 11 04" src="https://user-images.githubusercontent.com/152863/91837691-3cc9a280-ec44-11ea-8bfb-eeeb746919b8.png">
