### PR TITLE
test: add actor deletion test vectors

### DIFF
--- a/chaos/actor.go
+++ b/chaos/actor.go
@@ -45,7 +45,7 @@ const (
 	MethodDeleteActor
 )
 
-// Exports defines the methods this actor exposes publically.
+// Exports defines the methods this actor exposes publicly.
 func (a Actor) Exports() []interface{} {
 	return []interface{}{
 		builtin.MethodConstructor: a.Constructor,

--- a/chaos/actor.go
+++ b/chaos/actor.go
@@ -41,19 +41,24 @@ const (
 	MethodCallerValidation = builtin.MethodConstructor + iota
 	MethodCreateActor
 	MethodResolveAddress
+	// MethodDeleteActor is the identifier for the method that deletes this actor.
+	MethodDeleteActor
 )
 
+// Exports defines the methods this actor exposes publically.
 func (a Actor) Exports() []interface{} {
 	return []interface{}{
 		builtin.MethodConstructor: a.Constructor,
 		MethodCallerValidation:    a.CallerValidation,
 		MethodCreateActor:         a.CreateActor,
 		MethodResolveAddress:      a.ResolveAddress,
+		MethodDeleteActor:         a.DeleteActor,
 	}
 }
 
 var _ abi.Invokee = Actor{}
 
+// Constructor will panic since the Chaos actor is a singleton.
 func (a Actor) Constructor(_ runtime.Runtime, _ *adt.EmptyValue) *adt.EmptyValue {
 	panic("constructor should not be called; the Chaos actor is a singleton actor")
 }
@@ -133,4 +138,12 @@ func (a Actor) ResolveAddress(rt runtime.Runtime, args *address.Address) *Resolv
 		resolvedAddr = invalidAddr
 	}
 	return &ResolveAddressResponse{resolvedAddr, ok}
+}
+
+// DeleteActor deletes the executing actor from the state tree, transferring any
+// balance to beneficiary.
+func (a Actor) DeleteActor(rt runtime.Runtime, beneficiary *address.Address) *adt.EmptyValue {
+	rt.ValidateImmediateCallerAcceptAny()
+	rt.DeleteActor(*beneficiary)
+	return nil
 }

--- a/gen/builders/asserter.go
+++ b/gen/builders/asserter.go
@@ -115,7 +115,8 @@ func (a *Asserter) ActorMissing(addr address.Address) {
 // LastMessageResultSatisfies verifies that the last applied message result
 // satisfies the provided predicate.
 func (a *Asserter) LastMessageResultSatisfies(predicate ApplyRetPredicate) {
-	except := a.b.Messages.messages[0 : len(a.b.Messages.messages)-1]
+	msgs := a.suppliers.messages()
+	except := msgs[0 : len(msgs)-1]
 	a.EveryMessageResultSatisfies(predicate, except...)
 }
 

--- a/gen/builders/asserter.go
+++ b/gen/builders/asserter.go
@@ -112,6 +112,13 @@ func (a *Asserter) ActorMissing(addr address.Address) {
 	a.Error(err, "expected error while looking up actor %s", addr)
 }
 
+// LastMessageResultSatisfies verifies that the last applied message result
+// satisfies the provided predicate.
+func (a *Asserter) LastMessageResultSatisfies(predicate ApplyRetPredicate) {
+	except := a.b.Messages.messages[0 : len(a.b.Messages.messages)-1]
+	a.EveryMessageResultSatisfies(predicate, except...)
+}
+
 // EveryMessageResultSatisfies verifies that every message result satisfies the
 // provided predicate.
 func (a *Asserter) EveryMessageResultSatisfies(predicate ApplyRetPredicate, except ...*ApplicableMessage) {

--- a/gen/suites/actor_deletion/main.go
+++ b/gen/suites/actor_deletion/main.go
@@ -36,6 +36,7 @@ func main() {
 			MessageFunc: deleteActorWithBeneficiary(big.NewInt(50), address.Undef, exitcode.Ok),
 		},
 		// TODO: uncomment when merged https://github.com/filecoin-project/lotus/pull/3479
+		// It is not marked with HintInvalid because it panics entirely.
 		// &VectorDef{
 		// 	Metadata: &Metadata{
 		// 		ID:      "fail-delete-w-balance-and-unkown-beneficiary",

--- a/gen/suites/actor_deletion/main.go
+++ b/gen/suites/actor_deletion/main.go
@@ -72,7 +72,7 @@ func deleteActor(v *MessageVectorBuilder) {
 	v.Assert.ActorExists(chaos.Address)
 	v.Assert.BalanceEq(chaos.Address, big.Zero())
 
-	delMsg := v.Messages.Raw(
+	v.Messages.Raw(
 		sender.ID,
 		chaos.Address,
 		chaos.MethodDeleteActor,
@@ -82,7 +82,7 @@ func deleteActor(v *MessageVectorBuilder) {
 	)
 	v.CommitApplies()
 
-	v.Assert.NoError(ExitCode(exitcode.Ok)(delMsg.Result))
+	v.Assert.LastMessageResultSatisfies(ExitCode(exitcode.Ok))
 	v.Assert.ActorMissing(chaos.Address)
 }
 

--- a/gen/suites/actor_deletion/main.go
+++ b/gen/suites/actor_deletion/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/test-vectors/chaos"
+	. "github.com/filecoin-project/test-vectors/gen/builders"
+	. "github.com/filecoin-project/test-vectors/schema"
+)
+
+func main() {
+	g := NewGenerator()
+	defer g.Wait()
+
+	g.MessageVectorGroup("no_beneficiary",
+		&MessageVectorGenItem{
+			Metadata: &Metadata{
+				ID:      "delete-w-zero-balance",
+				Version: "v1",
+				Desc:    "actor with zero balance is deleted, does not require beneficiary",
+			},
+			Selector: Selector{"chaos_actor": "true"},
+			Func:     deleteActor,
+		},
+	)
+
+	g.MessageVectorGroup("beneficiary",
+		&MessageVectorGenItem{
+			Metadata: &Metadata{
+				ID:      "delete-w-balance-and-beneficiary",
+				Version: "v1",
+				Desc:    "actor with non-zero balance is deleted and sends funds to beneficiary",
+			},
+			Selector: Selector{"chaos_actor": "true"},
+			Func:     deleteActorWithBeneficiary(big.NewInt(50), address.Undef, exitcode.Ok),
+		},
+		// FIXME: this currently panics
+		// &MessageVectorGenItem{
+		// 	Metadata: &Metadata{
+		// 		ID:      "fail-delete-w-balance-and-unkown-beneficiary",
+		// 		Version: "v1",
+		// 		Desc:    "fails when actor with non-zero balance is deleted but beneficiary address is unknown",
+		// 	},
+		// 	Selector: Selector{"chaos_actor": "true"},
+		// 	Func:     deleteActorWithBeneficiary(big.NewInt(50), MustNewSECP256K1Addr("!👹*_👹!"), exitcode.SysErrorIllegalActor),
+		// },
+		&MessageVectorGenItem{
+			Metadata: &Metadata{
+				ID:      "fail-delete-w-balance-and-self-beneficiary",
+				Version: "v1",
+				Desc:    "fails when actor with non-zero balance is deleted but beneficiary is the calling actor",
+				Comment: "should abort if the beneficiary is the calling actor, see https://github.com/filecoin-project/specs-actors/blob/bcd83e8eb0a98b684851e574a2bd8d4130e21a51/actors/runtime/runtime.go#L117",
+			},
+			Selector: Selector{"chaos_actor": "true"},
+			Hints:    []string{HintIncorrect, HintNegate},
+			Func:     deleteActorWithBeneficiary(big.NewInt(50), chaos.Address, exitcode.Ok),
+		},
+	)
+}
+
+// deleteActor builds a test vector that tests the simple case of deleting an
+// actor with zero balance.
+func deleteActor(v *Builder) {
+	v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
+
+	sender := v.Actors.Account(address.SECP256K1, big.NewInt(1_000_000_000_000_000))
+	v.CommitPreconditions()
+
+	v.Assert.ActorExists(chaos.Address)
+	v.Assert.BalanceEq(chaos.Address, big.Zero())
+
+	delMsg := v.Messages.Raw(
+		sender.ID,
+		chaos.Address,
+		chaos.MethodDeleteActor,
+		MustSerialize(&builtin.BurntFundsActorAddr),
+		Value(big.Zero()),
+		Nonce(0),
+	)
+	v.CommitApplies()
+
+	v.Assert.NoError(ExitCode(exitcode.Ok)(delMsg.Result))
+	v.Assert.ActorMissing(chaos.Address)
+}
+
+// deleteActorWithBeneficiary builds a test vector that tests deleting an actor
+// and transfering their funds to another actor. Use address.Undef to have a
+// beneficiary created automatically. actorFunds MUST be greater than zero.
+func deleteActorWithBeneficiary(actorFunds big.Int, beneficiaryAddr address.Address, code exitcode.ExitCode) func(v *Builder) {
+	return func(v *Builder) {
+		v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
+
+		sender := v.Actors.Account(address.SECP256K1, big.Add(big.NewInt(1_000_000_000_000_000), actorFunds))
+
+		if beneficiaryAddr == address.Undef {
+			beneficiaryAddr = v.Actors.Account(address.SECP256K1, big.Zero()).ID
+		}
+
+		v.CommitPreconditions()
+
+		v.Assert.ActorExists(chaos.Address)
+		v.Assert.BalanceEq(chaos.Address, big.Zero())
+
+		// transfer required funds to the actor that will be deleted
+		m := v.Messages.Sugar().Transfer(sender.ID, chaos.Address, Value(actorFunds), Nonce(0))
+		v.Messages.ApplyOne(m)
+		v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.Ok))
+
+		// if this is will succeed, record the current balance so we can check funds
+		// were transferred to the beneficiary
+		var bal big.Int
+		if code == exitcode.Ok {
+			bal = v.Actors.Balance(beneficiaryAddr)
+		}
+
+		v.Messages.Raw(
+			sender.ID,
+			chaos.Address,
+			chaos.MethodDeleteActor,
+			MustSerialize(&beneficiaryAddr),
+			Value(big.Zero()),
+			Nonce(1),
+		)
+		v.CommitApplies()
+
+		v.Assert.LastMessageResultSatisfies(ExitCode(code))
+
+		// check beneficiary received funds if it succeeded
+		if code == exitcode.Ok && beneficiaryAddr != chaos.Address {
+			v.Assert.ActorMissing(chaos.Address)
+			v.Assert.BalanceEq(beneficiaryAddr, big.Add(bal, actorFunds))
+		}
+	}
+}

--- a/gen/suites/actor_deletion/main.go
+++ b/gen/suites/actor_deletion/main.go
@@ -35,15 +35,15 @@ func main() {
 			Selector:    schema.Selector{"chaos_actor": "true"},
 			MessageFunc: deleteActorWithBeneficiary(big.NewInt(50), address.Undef, exitcode.Ok),
 		},
-		// FIXME: this currently panics
+		// TODO: uncomment when merged https://github.com/filecoin-project/lotus/pull/3479
 		// &VectorDef{
 		// 	Metadata: &Metadata{
 		// 		ID:      "fail-delete-w-balance-and-unkown-beneficiary",
 		// 		Version: "v1",
 		// 		Desc:    "fails when actor with non-zero balance is deleted but beneficiary address is unknown",
 		// 	},
-		// 	Selector: Selector{"chaos_actor": "true"},
-		// 	MessageFunc:     deleteActorWithBeneficiary(big.NewInt(50), MustNewSECP256K1Addr("!👹*_👹!"), exitcode.SysErrorIllegalActor),
+		// 	Selector:    schema.Selector{"chaos_actor": "true"},
+		// 	MessageFunc: deleteActorWithBeneficiary(big.NewInt(50), MustNewSECP256K1Addr("!👹*_👹!"), exitcode.SysErrorIllegalActor),
 		// },
 		&VectorDef{
 			Metadata: &Metadata{

--- a/gen/suites/actor_deletion/main.go
+++ b/gen/suites/actor_deletion/main.go
@@ -89,7 +89,7 @@ func deleteActor(v *MessageVectorBuilder) {
 // deleteActorWithBeneficiary builds a test vector that tests deleting an actor
 // and transfering their funds to another actor. Use address.Undef to have a
 // beneficiary created automatically. actorFunds MUST be greater than zero.
-func deleteActorWithBeneficiary(actorFunds big.Int, beneficiaryAddr address.Address, code exitcode.ExitCode) func(v *MessageVectorBuilder) {
+func deleteActorWithBeneficiary(actorFunds big.Int, beneficiaryAddr address.Address, expectedCode exitcode.ExitCode) func(v *MessageVectorBuilder) {
 	return func(v *MessageVectorBuilder) {
 		v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
 
@@ -112,7 +112,7 @@ func deleteActorWithBeneficiary(actorFunds big.Int, beneficiaryAddr address.Addr
 		// if this is will succeed, record the current balance so we can check funds
 		// were transferred to the beneficiary
 		var bal big.Int
-		if code == exitcode.Ok {
+		if expectedCode == exitcode.Ok {
 			bal = v.StateTracker.Balance(beneficiaryAddr)
 		}
 
@@ -126,10 +126,10 @@ func deleteActorWithBeneficiary(actorFunds big.Int, beneficiaryAddr address.Addr
 		)
 		v.CommitApplies()
 
-		v.Assert.LastMessageResultSatisfies(ExitCode(code))
+		v.Assert.LastMessageResultSatisfies(ExitCode(expectedCode))
 
 		// check beneficiary received funds if it succeeded
-		if code == exitcode.Ok && beneficiaryAddr != chaos.Address {
+		if expectedCode == exitcode.Ok && beneficiaryAddr != chaos.Address {
 			v.Assert.ActorMissing(chaos.Address)
 			v.Assert.BalanceEq(beneficiaryAddr, big.Add(bal, actorFunds))
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -85,7 +85,7 @@ type Receipt struct {
 type Postconditions struct {
 	StateTree     *StateTree `json:"state_tree"`
 	Receipts      []*Receipt `json:"receipts"`
-	ReceiptsRoots []cid.Cid  `json:"receipts_roots"`
+	ReceiptsRoots []cid.Cid  `json:"receipts_roots,omitempty"`
 }
 
 // MarshalJSON implements json.Marshal for Base64EncodedBytes


### PR DESCRIPTION
This PR adds tests for actor deletion.

It adds a method to the chaos actor allowing it to delete itself.

...and adds test vectors for:

* Successful deletion of actor with zero balance
* Successful deletion of actor with non-zero balance, with transfer to beneficiary
* Failure to delete actor with non zero balance and beneficiary is unknown
* Failure to delete actor with non zero balance and beneficiary is calling actor

resolves #14