### PR TITLE
feat: chaos send (partially deprecate puppet actor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ not be seen in properly implemented actor code. To induce those situations,
 those vectors rely on a special test harness actor that sits "on the inside"
 and triggers those situations when specific messages are sent to it.
 
-The **Chaos Actor (address `t97`):** exercises behaviours that should be
+The **Chaos Actor (address `t97`)** exercises behaviours that should be
 regarded as illegal by the VM. Its ABI spec is part of this testing spec, and
 it's currently being heavily developed.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ $ make upgen
 $ make regen
 ```
 
-## Special test harness actors
+## Special test harness actor
 
 > 💡 Remember that an Actor in Filecoin is the equivalent of a "smart contract"
 > in other blockchains. Currently, Filecoin does not support user-programmable
@@ -255,19 +255,20 @@ $ make regen
 
 In order to test VM correctness, some vectors exercise situations that should
 not be seen in properly implemented actor code. To induce those situations,
-those vectors rely on two special test harness actors that sit "on the inside"
-and trigger those situations when specific messages are sent to it.
+those vectors rely on a special test harness actor that sits "on the inside"
+and triggers those situations when specific messages are sent to it.
 
- * **Chaos Actor (address `t97`):** exercises behaviours that should be regarded
-   as illegal by the VM. Its ABI spec is part of this testing spec, and it's
-   currently being heavily developed.
-     * Test vectors requiring the **Chaos actor** carry the `chaos_actor:true`
-       selector. 
-     * Refer to the implementation under the [`chaos` package](./chaos).
-     * Once stable, we will document this actor in a spec.
+The **Chaos Actor (address `t97`):** exercises behaviours that should be
+regarded as illegal by the VM. Its ABI spec is part of this testing spec, and
+it's currently being heavily developed.
+
+* Test vectors requiring the **Chaos Actor** carry the `chaos_actor:true`
+  selector.
+* Refer to the implementation under the [`chaos` package](./chaos).
+* Once stable, we will document this actor in a spec.
    
-To benefit from maximum testing coverage, implementations should implement these
-actors and make their test drivers deploy them in the test VM. The Chaos actor
+To benefit from maximum testing coverage, implementations should implement this
+actor and make their test drivers deploy them in the test VM. The Chaos actor
 should only be deployed when the cited selector is present.
 
 ## Broken/incorrect vectors

--- a/README.md
+++ b/README.md
@@ -265,12 +265,6 @@ and trigger those situations when specific messages are sent to it.
        selector. 
      * Refer to the implementation under the [`chaos` package](./chaos).
      * Once stable, we will document this actor in a spec.
- * **Puppet Actor (address `t98`):** former testing harness that includes
-   methods for invalid sending messages and returning invalid values. It's in
-   the process of being deprecated and consolidated into the **Chaos actor**
-   (track [#61](https://github.com/filecoin-project/test-vectors/issues/61).
-     * Test vectors requiring the **Puppet actor** carry the `puppet_actor:true`
-       selector. 
    
 To benefit from maximum testing coverage, implementations should implement these
 actors and make their test drivers deploy them in the test VM. The Chaos actor

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ implementations to test their correctness and compliance with the
 - [Test vector generation (`gen` directory)](#test-vector-generation-gen-directory)
   - [How are vectors generated?](#how-are-vectors-generated)
   - [Running the generation scripts](#running-the-generation-scripts)
-- [Special test harness actors](#special-test-harness-actors)
+- [Special test harness actor](#special-test-harness-actor)
 - [Broken/incorrect vectors](#brokenincorrect-vectors)
 - [Integration in Lotus](#integration-in-lotus)
 - [Testing the conformance of a Filecoin implementation](#testing-the-conformance-of-a-filecoin-implementation)

--- a/chaos/actor.go
+++ b/chaos/actor.go
@@ -86,25 +86,16 @@ func (a Actor) Send(rt runtime.Runtime, args *SendArgs) *SendReturn {
 		runtime.CBORBytes(args.Params),
 		args.Value,
 	)
-	out, err := handleSendReturn(ret)
-	if err != nil {
-		rt.Abortf(exitcode.ErrIllegalState, "failed to unmarshal send return: %v", err)
+	var out runtime.CBORBytes
+	if ret != nil {
+		if err := ret.Into(&out); err != nil {
+			rt.Abortf(exitcode.ErrIllegalState, "failed to unmarshal send return: %v", err)
+		}
 	}
 	return &SendReturn{
 		Return: out,
 		Code:   code,
 	}
-}
-
-func handleSendReturn(ret runtime.SendReturn) (runtime.CBORBytes, error) {
-	if ret == nil {
-		return nil, nil // nothing was returned
-	}
-	var out runtime.CBORBytes
-	if err := ret.Into(&out); err != nil {
-		return nil, err
-	}
-	return out, nil
 }
 
 // Constructor will panic because the Chaos actor is a singleton.

--- a/chaos/cbor_gen.go
+++ b/chaos/cbor_gen.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )
@@ -269,6 +271,230 @@ func (t *ResolveAddressResponse) UnmarshalCBOR(r io.Reader) error {
 		t.Success = true
 	default:
 		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+	}
+	return nil
+}
+
+var lengthBufSendArgs = []byte{132}
+
+func (t *SendArgs) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufSendArgs); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.To (address.Address) (struct)
+	if err := t.To.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Value (big.Int) (struct)
+	if err := t.Value.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Method (abi.MethodNum) (uint64)
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Method)); err != nil {
+		return err
+	}
+
+	// t.Params ([]uint8) (slice)
+	if len(t.Params) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.Params was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Params))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.Params[:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *SendArgs) UnmarshalCBOR(r io.Reader) error {
+	*t = SendArgs{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 4 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.To (address.Address) (struct)
+
+	{
+
+		if err := t.To.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.To: %w", err)
+		}
+
+	}
+	// t.Value (big.Int) (struct)
+
+	{
+
+		if err := t.Value.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Value: %w", err)
+		}
+
+	}
+	// t.Method (abi.MethodNum) (uint64)
+
+	{
+
+		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Method = abi.MethodNum(extra)
+
+	}
+	// t.Params ([]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.Params: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.Params = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.Params[:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+var lengthBufSendReturn = []byte{130}
+
+func (t *SendReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufSendReturn); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Return (runtime.CBORBytes) (slice)
+	if len(t.Return) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.Return was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Return))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.Return[:]); err != nil {
+		return err
+	}
+
+	// t.Code (exitcode.ExitCode) (int64)
+	if t.Code >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Code)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Code-1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *SendReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = SendReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Return (runtime.CBORBytes) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.Return: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.Return = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.Return[:]); err != nil {
+		return err
+	}
+	// t.Code (exitcode.ExitCode) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Code = exitcode.ExitCode(extraI)
 	}
 	return nil
 }

--- a/chaos/gen/gen.go
+++ b/chaos/gen/gen.go
@@ -11,6 +11,8 @@ func main() {
 		chaos.State{},
 		chaos.CreateActorArgs{},
 		chaos.ResolveAddressResponse{},
+		chaos.SendArgs{},
+		chaos.SendReturn{},
 	); err != nil {
 		panic(err)
 	}

--- a/gen/builders/messages_typed.go
+++ b/gen/builders/messages_typed.go
@@ -366,7 +366,7 @@ func InitExec(params *init_.ExecParams) TypedCall {
 // | CHAOS
 // ----------------------------------------------------------------------------
 
-// ChaosSend is a message to a chaos actor that sends a messgae to another actor.
+// ChaosSend is a message to a chaos actor that sends a message to another actor.
 func ChaosSend(args *chaos.SendArgs) TypedCall {
 	return func() (abi.MethodNum, []byte) {
 		return chaos.MethodSend, MustSerialize(args)

--- a/gen/builders/messages_typed.go
+++ b/gen/builders/messages_typed.go
@@ -2,10 +2,10 @@ package builders
 
 import (
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/test-vectors/chaos"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
-	"github.com/filecoin-project/specs-actors/actors/puppet"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
@@ -363,17 +363,12 @@ func InitExec(params *init_.ExecParams) TypedCall {
 }
 
 // ----------------------------------------------------------------------------
-// | PUPPET
+// | CHAOS
 // ----------------------------------------------------------------------------
 
-func PuppetConstructor(params *adt.EmptyValue) TypedCall {
+// ChaosSend is a message to a chaos actor that sends a messgae to another actor.
+func ChaosSend(args *chaos.SendArgs) TypedCall {
 	return func() (abi.MethodNum, []byte) {
-		return puppet.MethodsPuppet.Constructor, MustSerialize(params)
-	}
-}
-
-func PuppetSend(params *puppet.SendParams) TypedCall {
-	return func() (abi.MethodNum, []byte) {
-		return puppet.MethodsPuppet.Send, MustSerialize(params)
+		return chaos.MethodSend, MustSerialize(args)
 	}
 }

--- a/gen/suites/nested/main.go
+++ b/gen/suites/nested/main.go
@@ -118,7 +118,7 @@ func main() {
 				Version: "v1",
 				Desc:    "",
 			},
-			Selector:    map[string]string{"puppet_actor": "true"},
+			Selector:    map[string]string{"chaos_actor": "true"},
 			MessageFunc: nestedSends_FailInsufficientFundsForTransferInInnerSend,
 		},
 	)


### PR DESCRIPTION
Adds `Send` functionality from the puppet actor removing dependence on it from this repo.

Fixes #61.