### PR TITLE
migrate duplicate msgs and gas cost tipset tests from chain-validation.

### DIFF
--- a/gen/builders/wallet.go
+++ b/gen/builders/wallet.go
@@ -28,6 +28,7 @@ func NewWallet() *Wallet {
 	return &Wallet{
 		keys:     make(map[address.Address]*wallet.Key),
 		secpSeed: 0,
+		blsSeed:  1,
 	}
 }
 
@@ -56,7 +57,6 @@ func (w *Wallet) Sign(addr address.Address, data []byte) (acrypto.Signature, err
 		if err != nil {
 			return acrypto.Signature{}, err
 		}
-
 		return acrypto.Signature{
 			Type: sigType,
 			Data: sig,
@@ -90,7 +90,7 @@ func (w *Wallet) newBLSKey() *wallet.Key {
 	// FIXME: bls needs deterministic key generation
 	//sk := ffi.PrivateKeyGenerate(s.blsSeed)
 	// s.blsSeed++
-	sk := [32]byte{}
+	var sk [32]byte
 	sk[0] = uint8(w.blsSeed) // hack to keep gas values determinist
 	w.blsSeed++
 	key, err := wallet.NewKey(types.KeyInfo{

--- a/gen/suites/msg_application/duplicates.go
+++ b/gen/suites/msg_application/duplicates.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+
+	. "github.com/filecoin-project/test-vectors/gen/builders"
+)
+
+func minerIncludesDuplicateMessages(v *TipsetVectorBuilder) {
+	var (
+		alice = v.Actors.Account(address.SECP256K1, balance1T)
+		bob   = v.Actors.Account(address.BLS, balance1T)
+	)
+
+	var miner1, miner2, miner3 Miner
+	v.Actors.MinerN(MinerActorCfg{
+		SealProofType:  TestSealProofType,
+		PeriodBoundary: 0,
+		OwnerBalance:   big.Zero(),
+	}, &miner1, &miner2, &miner3)
+
+	v.CommitPreconditions()
+
+	transferAmt := abi.NewTokenAmount(100)
+
+	v.StagedMessages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
+	v.StagedMessages.Sugar().Transfer(alice.Robust, alice.Robust, Value(transferAmt), Nonce(0))
+	v.StagedMessages.Sugar().Transfer(alice.Robust, alice.Robust, Value(transferAmt), Nonce(0))
+	v.StagedMessages.Sugar().Transfer(alice.Robust, alice.Robust, Value(transferAmt), Nonce(0))
+
+	v.StagedMessages.Sugar().Transfer(bob.Robust, bob.Robust, Value(transferAmt), Nonce(0))
+	v.StagedMessages.Sugar().Transfer(bob.Robust, bob.Robust, Value(transferAmt), Nonce(0))
+	v.StagedMessages.Sugar().Transfer(bob.Robust, bob.Robust, Value(transferAmt), Nonce(0))
+
+	ts := v.Tipsets.Next(abi.NewTokenAmount(100))
+	ts.Block(miner1, 1, v.StagedMessages.All()...)
+	ts.Block(miner2, 1, v.StagedMessages.All()...)
+	ts.Block(miner3, 1, v.StagedMessages.All()...)
+
+	v.CommitApplies()
+
+	v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.Ok))
+	v.Assert.Len(v.Tipsets.Messages(), 2)
+}

--- a/gen/suites/msg_application/main.go
+++ b/gen/suites/msg_application/main.go
@@ -18,6 +18,14 @@ func main() {
 	g.Group("gas_cost",
 		&VectorDef{
 			Metadata: &Metadata{
+				ID:      "msg-ok-secp-bls-gas-costs",
+				Version: "v1",
+				Desc:    "check the gas cost of secpk (higher) and BLS (lower) messages",
+			},
+			TipsetFunc: okSecpkBLSCosts,
+		},
+		&VectorDef{
+			Metadata: &Metadata{
 				ID:      "msg-apply-fail-receipt-gas",
 				Version: "v1",
 				Desc:    "fail to cover gas cost for message receipt on chain",
@@ -90,6 +98,17 @@ block validation we need to ensure behaviour is consistent across VM implementat
 				Desc:    "abort during actor execution due to illegal argument",
 			},
 			MessageFunc: failActorExecutionAborted,
+		},
+	)
+
+	g.Group("duplicates",
+		&VectorDef{
+			Metadata: &Metadata{
+				ID:      "messages-deduplicated",
+				Version: "v1",
+				Desc:    "duplicated messages in a block are deduplicated",
+			},
+			TipsetFunc: minerIncludesDuplicateMessages,
 		},
 	)
 

--- a/gen/suites/reward/main.go
+++ b/gen/suites/reward/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
@@ -54,9 +55,17 @@ func main() {
 			TipsetFunc: minerPenalized(3, func(v *TipsetVectorBuilder) {
 				v.StagedMessages.SetDefaults(GasLimit(1_000_000_000), GasPremium(0), GasFeeCap(200))
 
-				from := v.Actors.Miners()[0].MinerActorAddr.Robust
+				from := []address.Address{
+					v.Actors.Miners()[0].MinerActorAddr.Robust,
+					builtin.SystemActorAddr,
+					builtin.InitActorAddr,
+					builtin.CronActorAddr,
+				}
+
 				to := v.Actors.Miners()[0].OwnerAddr.Robust // sending funds to the first miner's owner account
-				v.StagedMessages.Sugar().Transfer(from, to, Value(abi.NewTokenAmount(1)), Nonce(0))
+				for i, f := range from {
+					v.StagedMessages.Sugar().Transfer(f, to, Value(abi.NewTokenAmount(1)), Nonce(uint64(i)))
+				}
 			}, nil),
 		},
 		&VectorDef{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.3
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
-	github.com/filecoin-project/lotus v0.5.8-0.20200903144844-d8d38ffc56e3
+	github.com/filecoin-project/lotus v0.5.8-0.20200903215419-8e7a8d8c970a
 	github.com/filecoin-project/specs-actors v0.9.3
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/filecoin-project/lotus v0.5.8-0.20200901153315-fa4000663a61 h1:+pL/Nj
 github.com/filecoin-project/lotus v0.5.8-0.20200901153315-fa4000663a61/go.mod h1:gs5PdzCNGg5vhLMFh3VnUnyvCYXCKJH6Rw2k/PVz1uU=
 github.com/filecoin-project/lotus v0.5.8-0.20200902130912-0962292f920e h1:ZHH2ByhZcNRoGlTP6GX9EZTdrfh2LVH4doGuW+mxoUw=
 github.com/filecoin-project/lotus v0.5.8-0.20200902130912-0962292f920e/go.mod h1:OkZ5aUqs+fFnJOq9243WJDsTa9c3/Ae67NIAwVhAB+0=
-github.com/filecoin-project/lotus v0.5.8-0.20200903144844-d8d38ffc56e3 h1:eHzEgAlCCq5YBWOR+lNzbxFIpH7vUuwN9NZ9G8LWgpg=
-github.com/filecoin-project/lotus v0.5.8-0.20200903144844-d8d38ffc56e3/go.mod h1:wxuzS4ozpCFThia18G+J5P0Jp/DSiq9ezzJF1yvZuP4=
+github.com/filecoin-project/lotus v0.5.8-0.20200903215419-8e7a8d8c970a h1:8Vk22cYOQjEiwYd5pFC59s/hm6LTxdJl3xiepi1Vm0A=
+github.com/filecoin-project/lotus v0.5.8-0.20200903215419-8e7a8d8c970a/go.mod h1:wxuzS4ozpCFThia18G+J5P0Jp/DSiq9ezzJF1yvZuP4=
 github.com/filecoin-project/sector-storage v0.0.0-20200712023225-1d67dcfa3c15/go.mod h1:salgVdX7qeXFo/xaiEQE29J4pPkjn71T0kt0n+VDBzo=
 github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a h1:oDYwbXXcbMYrQX1CgYd2Zwb4ocghYw1zBctvCTW1RoE=
 github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a/go.mod h1:oOawOl9Yk+qeytLzzIryjI8iRbqo+qzS6EEeElP4PWA=


### PR DESCRIPTION
With this merged, we can deprecate chain-validation entirely.