### PR TITLE
upgrade lotus: import latest changes to driver.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.3
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
-	github.com/filecoin-project/lotus v0.5.8-0.20200903215419-8e7a8d8c970a
+	github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf
 	github.com/filecoin-project/specs-actors v0.9.3
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/filecoin-project/lotus v0.5.8-0.20200901153315-fa4000663a61 h1:+pL/Nj
 github.com/filecoin-project/lotus v0.5.8-0.20200901153315-fa4000663a61/go.mod h1:gs5PdzCNGg5vhLMFh3VnUnyvCYXCKJH6Rw2k/PVz1uU=
 github.com/filecoin-project/lotus v0.5.8-0.20200902130912-0962292f920e h1:ZHH2ByhZcNRoGlTP6GX9EZTdrfh2LVH4doGuW+mxoUw=
 github.com/filecoin-project/lotus v0.5.8-0.20200902130912-0962292f920e/go.mod h1:OkZ5aUqs+fFnJOq9243WJDsTa9c3/Ae67NIAwVhAB+0=
-github.com/filecoin-project/lotus v0.5.8-0.20200903215419-8e7a8d8c970a h1:8Vk22cYOQjEiwYd5pFC59s/hm6LTxdJl3xiepi1Vm0A=
-github.com/filecoin-project/lotus v0.5.8-0.20200903215419-8e7a8d8c970a/go.mod h1:wxuzS4ozpCFThia18G+J5P0Jp/DSiq9ezzJF1yvZuP4=
+github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf h1:AFhnhDF7vCRzlolb20nQWOwA9+lk4rnEMXPE2AmhwoE=
+github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf/go.mod h1:wxuzS4ozpCFThia18G+J5P0Jp/DSiq9ezzJF1yvZuP4=
 github.com/filecoin-project/sector-storage v0.0.0-20200712023225-1d67dcfa3c15/go.mod h1:salgVdX7qeXFo/xaiEQE29J4pPkjn71T0kt0n+VDBzo=
 github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a h1:oDYwbXXcbMYrQX1CgYd2Zwb4ocghYw1zBctvCTW1RoE=
 github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a/go.mod h1:oOawOl9Yk+qeytLzzIryjI8iRbqo+qzS6EEeElP4PWA=


### PR DESCRIPTION
This should also fix the build after merging the Chaos actor address replacement.

Points to https://github.com/filecoin-project/lotus/pull/3521.