### PR TITLE
Update imports blocked on up to date lotus

### DIFF
--- a/chaos/actor.go
+++ b/chaos/actor.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/ipfs/go-cid"
 	"github.com/whyrusleeping/cbor-gen"

--- a/chaos/actor.go
+++ b/chaos/actor.go
@@ -2,7 +2,7 @@ package chaos
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
@@ -76,7 +76,7 @@ func (a Actor) Exports() []interface{} {
 	}
 }
 
-var _ abi.Invokee = Actor{}
+var _ runtime.Invokee = Actor{}
 
 // SendArgs are the arguments for the Send method.
 type SendArgs struct {

--- a/chaos/cbor_gen.go
+++ b/chaos/cbor_gen.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	abi "github.com/filecoin-project/go-state-types/abi"
-	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	exitcode "github.com/filecoin-project/go-state-types/exitcode"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )

--- a/chaos/cbor_gen.go
+++ b/chaos/cbor_gen.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	abi "github.com/filecoin-project/specs-actors/actors/abi"
+	abi "github.com/filecoin-project/go-state-types/abi"
 	exitcode "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"

--- a/gen/builders/actors.go
+++ b/gen/builders/actors.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/types"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/account"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"

--- a/gen/builders/actors.go
+++ b/gen/builders/actors.go
@@ -156,7 +156,7 @@ func (a *Actors) Miner(cfg MinerActorCfg) Miner {
 	ss, err := cfg.SealProofType.SectorSize()
 	a.bc.Assert.NoError(err, "seal proof sector size")
 
-	ps, err := cfg.SealProofType.WindowPoStPartitionSectors()
+	ps, err := builtin.SealProofWindowPoStPartitionSectors(cfg.SealProofType)
 	a.bc.Assert.NoError(err, "seal proof window PoSt partition sectors")
 
 	mi := &miner.MinerInfo{

--- a/gen/builders/asserter.go
+++ b/gen/builders/asserter.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/state"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/go-address"
 

--- a/gen/builders/builder_tipset.go
+++ b/gen/builders/builder_tipset.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	lotus "github.com/filecoin-project/lotus/conformance"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/ipfs/go-cid"
 )

--- a/gen/builders/gas.go
+++ b/gen/builders/gas.go
@@ -3,8 +3,8 @@ package builders
 import (
 	lotus "github.com/filecoin-project/lotus/conformance"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 )
 
 const (

--- a/gen/builders/messages.go
+++ b/gen/builders/messages.go
@@ -2,8 +2,8 @@ package builders
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"

--- a/gen/builders/messages_sugar.go
+++ b/gen/builders/messages_sugar.go
@@ -3,7 +3,7 @@ package builders
 import (
 	"github.com/filecoin-project/go-address"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"

--- a/gen/builders/messages_typed.go
+++ b/gen/builders/messages_typed.go
@@ -4,8 +4,8 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/test-vectors/chaos"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"

--- a/gen/builders/messages_typed.go
+++ b/gen/builders/messages_typed.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
+	"github.com/filecoin-project/specs-actors/actors/runtime/proof"
 )
 
 func Transfer() TypedCall {
@@ -271,7 +272,7 @@ func PowerOnConsensusFault(params *big.Int) TypedCall {
 		return builtin.MethodsPower.OnConsensusFault, MustSerialize(params)
 	}
 }
-func PowerSubmitPoRepForBulkVerify(params *abi.SealVerifyInfo) TypedCall {
+func PowerSubmitPoRepForBulkVerify(params *proof.SealVerifyInfo) TypedCall {
 	return func() (abi.MethodNum, []byte) {
 		return builtin.MethodsPower.SubmitPoRepForBulkVerify, MustSerialize(params)
 	}

--- a/gen/builders/predicates.go
+++ b/gen/builders/predicates.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	cbg "github.com/whyrusleeping/cbor-gen"
 )

--- a/gen/builders/predicates.go
+++ b/gen/builders/predicates.go
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 

--- a/gen/builders/reward.go
+++ b/gen/builders/reward.go
@@ -3,8 +3,8 @@ package builders
 import (
 	"context"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 )

--- a/gen/builders/state_tracker.go
+++ b/gen/builders/state_tracker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 

--- a/gen/builders/state_zero.go
+++ b/gen/builders/state_zero.go
@@ -2,8 +2,9 @@ package builders
 
 import (
 	"context"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/account"
 	"github.com/filecoin-project/specs-actors/actors/builtin/cron"

--- a/gen/builders/tipsets.go
+++ b/gen/builders/tipsets.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/filecoin-project/test-vectors/schema"
 
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 )
 
 // TipsetSeq is a sequence of tipsets to be applied during the test.

--- a/gen/builders/wallet.go
+++ b/gen/builders/wallet.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-crypto"
 
-	acrypto "github.com/filecoin-project/specs-actors/actors/crypto"
+	acrypto "github.com/filecoin-project/go-state-types/crypto"
 	"github.com/minio/blake2b-simd"
 )
 

--- a/gen/suites/actor_creation/addresses.go
+++ b/gen/suites/actor_creation/addresses.go
@@ -3,7 +3,7 @@ package main
 import (
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/big"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 
 	"github.com/filecoin-project/go-address"

--- a/gen/suites/actor_creation/main.go
+++ b/gen/suites/actor_creation/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/actor_creation/main.go
+++ b/gen/suites/actor_creation/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 	"github.com/filecoin-project/test-vectors/schema"

--- a/gen/suites/actor_creation/on_tranfer.go
+++ b/gen/suites/actor_creation/on_tranfer.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/big"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/actor_creation/on_tranfer.go
+++ b/gen/suites/actor_creation/on_tranfer.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"

--- a/gen/suites/actor_creation/params.go
+++ b/gen/suites/actor_creation/params.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"

--- a/gen/suites/actor_creation/params.go
+++ b/gen/suites/actor_creation/params.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/actor_creation/params.go
+++ b/gen/suites/actor_creation/params.go
@@ -31,8 +31,8 @@ func createActorInitExecUnparsableParams(v *MessageVectorBuilder) {
 
 	v.CommitApplies()
 
-	// make sure that we get SysErrSerialization error code -- this assert currently fails.
-	v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.SysErrSerialization))
+	// make sure that we get ErrSerialization error code -- this assert currently fails.
+	v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.ErrSerialization))
 	// make sure that gas (not value) is deducted from senders's account
 	// (the BalanceUpdated predicate omits deducting the value if the exit code != success)
 	v.Assert.EveryMessageSenderSatisfies(BalanceUpdated(big.Zero()))
@@ -57,8 +57,8 @@ func createActorCtorUnparsableParamsViaInitExec(v *MessageVectorBuilder) {
 
 	v.CommitApplies()
 
-	// make sure that we get SysErrSerialization error code -- this assert currently fails.
-	v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.SysErrSerialization))
+	// make sure that we get ErrSerialization error code -- this assert currently fails.
+	v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.ErrSerialization))
 	// make sure that gas (not value) is deducted from senders's account
 	// (the BalanceUpdated predicate omits deducting the value if the exit code != success)
 	v.Assert.EveryMessageSenderSatisfies(BalanceUpdated(big.Zero()))

--- a/gen/suites/actor_deletion/main.go
+++ b/gen/suites/actor_deletion/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/test-vectors/chaos"
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 	"github.com/filecoin-project/test-vectors/schema"

--- a/gen/suites/actor_deletion/main.go
+++ b/gen/suites/actor_deletion/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/test-vectors/chaos"

--- a/gen/suites/msg_application/actor_exec.go
+++ b/gen/suites/msg_application/actor_exec.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"

--- a/gen/suites/msg_application/actor_exec.go
+++ b/gen/suites/msg_application/actor_exec.go
@@ -5,8 +5,8 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
-	"github.com/filecoin-project/specs-actors/actors/crypto"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/msg_application/duplicates.go
+++ b/gen/suites/msg_application/duplicates.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/msg_application/duplicates.go
+++ b/gen/suites/msg_application/duplicates.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/msg_application/gas_cost.go
+++ b/gen/suites/msg_application/gas_cost.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/msg_application/gas_cost.go
+++ b/gen/suites/msg_application/gas_cost.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/msg_application/invalid_msgs.go
+++ b/gen/suites/msg_application/invalid_msgs.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/msg_application/invalid_msgs.go
+++ b/gen/suites/msg_application/invalid_msgs.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/msg_application/main.go
+++ b/gen/suites/msg_application/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/msg_application/unknown_actors.go
+++ b/gen/suites/msg_application/unknown_actors.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/multisig/ok.go
+++ b/gen/suites/multisig/ok.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"

--- a/gen/suites/multisig/ok.go
+++ b/gen/suites/multisig/ok.go
@@ -6,7 +6,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/go-address"

--- a/gen/suites/nested/nested.go
+++ b/gen/suites/nested/nested.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"

--- a/gen/suites/nested/nested.go
+++ b/gen/suites/nested/nested.go
@@ -12,7 +12,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 	"github.com/filecoin-project/specs-actors/actors/runtime"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	typegen "github.com/whyrusleeping/cbor-gen"
 

--- a/gen/suites/paych/main.go
+++ b/gen/suites/paych/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/paych/ok.go
+++ b/gen/suites/paych/ok.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	"github.com/filecoin-project/specs-actors/actors/crypto"

--- a/gen/suites/paych/ok.go
+++ b/gen/suites/paych/ok.go
@@ -6,8 +6,8 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
-	"github.com/filecoin-project/specs-actors/actors/crypto"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/reward/main.go
+++ b/gen/suites/reward/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 

--- a/gen/suites/reward/main.go
+++ b/gen/suites/reward/main.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/reward/miner.go
+++ b/gen/suites/reward/miner.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/reward/miner.go
+++ b/gen/suites/reward/miner.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 

--- a/gen/suites/reward/penalties.go
+++ b/gen/suites/reward/penalties.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/transfer/basic.go
+++ b/gen/suites/transfer/basic.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/big"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/transfer/basic.go
+++ b/gen/suites/transfer/basic.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/big"

--- a/gen/suites/transfer/main.go
+++ b/gen/suites/transfer/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 

--- a/gen/suites/transfer/main.go
+++ b/gen/suites/transfer/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/transfer/self_transfer.go
+++ b/gen/suites/transfer/self_transfer.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/transfer/self_transfer.go
+++ b/gen/suites/transfer/self_transfer.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/transfer/system_receiver.go
+++ b/gen/suites/transfer/system_receiver.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/transfer/system_receiver.go
+++ b/gen/suites/transfer/system_receiver.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/transfer/unknown.go
+++ b/gen/suites/transfer/unknown.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/gen/suites/transfer/unknown.go
+++ b/gen/suites/transfer/unknown.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )

--- a/gen/suites/vm_violations/actor_creation.go
+++ b/gen/suites/vm_violations/actor_creation.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/test-vectors/chaos"

--- a/gen/suites/vm_violations/actor_creation.go
+++ b/gen/suites/vm_violations/actor_creation.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/ipfs/go-cid"

--- a/gen/suites/vm_violations/address_resolution.go
+++ b/gen/suites/vm_violations/address_resolution.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 
 	"github.com/filecoin-project/go-address"
 

--- a/gen/suites/vm_violations/address_resolution.go
+++ b/gen/suites/vm_violations/address_resolution.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 

--- a/gen/suites/vm_violations/caller_validation.go
+++ b/gen/suites/vm_violations/caller_validation.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	typegen "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/test-vectors/chaos"

--- a/gen/suites/vm_violations/caller_validation.go
+++ b/gen/suites/vm_violations/caller_validation.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	typegen "github.com/whyrusleeping/cbor-gen"
 

--- a/gen/suites/vm_violations/main.go
+++ b/gen/suites/vm_violations/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
 

--- a/gen/suites/vm_violations/state_mutation.go
+++ b/gen/suites/vm_violations/state_mutation.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/filecoin-project/test-vectors/chaos"
 

--- a/gen/suites/vm_violations/state_mutation.go
+++ b/gen/suites/vm_violations/state_mutation.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/test-vectors/chaos"
 
 	. "github.com/filecoin-project/test-vectors/gen/builders"

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,9 @@ require (
 	github.com/filecoin-project/go-address v0.0.3
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
+	github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4
 	github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf
-	github.com/filecoin-project/specs-actors v0.9.3
+	github.com/filecoin-project/specs-actors v0.9.4
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834
 	github.com/ipfs/go-cid v0.0.7

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/filecoin-project/go-address v0.0.3
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
-	github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4
+	github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df
 	github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf
-	github.com/filecoin-project/specs-actors v0.9.4
+	github.com/filecoin-project/specs-actors v0.9.6
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834
 	github.com/ipfs/go-cid v0.0.7

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df
-	github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf
+	github.com/filecoin-project/lotus v0.5.11-0.20200907070510-420a8706da6d
 	github.com/filecoin-project/specs-actors v0.9.6
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/filecoin-project/go-paramfetch v0.0.1/go.mod h1:fZzmf4tftbwf9S37XRifo
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200701152213-3e0f0afdc261 h1:A256QonvzRaknIIAuWhe/M2dpV2otzs3NBhi5TWa/UA=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200701152213-3e0f0afdc261/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
+github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4 h1:EG5midq073Dk3b1hgkjE/blVA2z9G7INKppmT5ZeCOs=
+github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v0.0.0-20200714194326-a77c3ae20989/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v0.0.0-20200813232949-df9b130df370 h1:Jbburj7Ih2iaJ/o5Q9A+EAeTabME6YII7FLi9SKUf5c=
@@ -279,6 +281,9 @@ github.com/filecoin-project/specs-actors v0.9.2 h1:0JG0QLHw8pO6BPqPRe9eQxQW60biH
 github.com/filecoin-project/specs-actors v0.9.2/go.mod h1:YasnVUOUha0DN5wB+twl+V8LlDKVNknRG00kTJpsfFA=
 github.com/filecoin-project/specs-actors v0.9.3 h1:Fi75G/UQ7R4eiIwnN+S6bBQ9LqKivyJdw62jJzTi6aE=
 github.com/filecoin-project/specs-actors v0.9.3/go.mod h1:YasnVUOUha0DN5wB+twl+V8LlDKVNknRG00kTJpsfFA=
+github.com/filecoin-project/specs-actors v0.9.4 h1:FePB+hrctHHiTbmaY4hnvBJzfgckN3eJreUZWpS5yks=
+github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
+github.com/filecoin-project/specs-actors v0.9.7 h1:7PAZ8kdqwBdmgf/23FCkQZLCXcVu02XJrkpkhBikiA8=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea h1:iixjULRQFPn7Q9KlIqfwLJnlAXO10bbkI+xy5GKGdLY=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea/go.mod h1:Pr5ntAaxsh+sLG/LYiL4tKzvA83Vk5vLODYhfNwOg7k=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200730063404-f7db367e9401 h1:jLzN1hwO5WpKPu8ASbW8fs1FUCsOWNvoBXzQhv+8/E8=

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGj
 github.com/fd/go-nat v1.0.0/go.mod h1:BTBu/CKvMmOMUPkKVef1pngt2WFH/lg7E6yQnulfp6E=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200813000554-40c22fe26eef h1:MtQRSnJLsQOOlmsd/Ua5KWXimpxcaa715h6FUh/eJPY=
 github.com/filecoin-project/chain-validation v0.0.6-0.20200813000554-40c22fe26eef/go.mod h1:SMj5VK1pYgqC8FXVEtOBRTc+9AIrYu+C+K3tAXi2Rk8=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200907020853-f4e4e7417fea h1:5a/3uCw2qqCNj16XJPXJj5fLePf2UQejjRPynorERjE=
+github.com/filecoin-project/chain-validation v0.0.6-0.20200907020853-f4e4e7417fea/go.mod h1:pKcH/ShsOvCpO2qnsGFzEJ0NMJdBenPRk4Uu/xpIEkY=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.3 h1:eVfbdjEbpbzIrbiSa+PiGUY+oDK9HnUn+M1R/ggoHf8=
@@ -235,6 +237,8 @@ github.com/filecoin-project/go-fil-markets v0.5.6-0.20200814234959-80b1788108ac/
 github.com/filecoin-project/go-fil-markets v0.5.6/go.mod h1:SJApXAKr5jyGpbzDEOhvemui0pih7hhT8r2MXJxCP1E=
 github.com/filecoin-project/go-fil-markets v0.5.8 h1:uwl0QNUVmmSlUQfxshpj21Dmhh6WKTQNhnb1GMfdp18=
 github.com/filecoin-project/go-fil-markets v0.5.8/go.mod h1:6ZX1vbZbnukbVQ8tCB/MmEizuW/bmRX7SpGAltU3KVg=
+github.com/filecoin-project/go-fil-markets v0.5.10-0.20200907054005-9945d0d2141a h1:SYWurOVYyEqajP3rr20F9UvkIpn6p9ewMk9yOg1kaVM=
+github.com/filecoin-project/go-fil-markets v0.5.10-0.20200907054005-9945d0d2141a/go.mod h1:w0wCAf/fT7UfvJAZEMjjCQfsbwvrdjU4sN4QFLWsPrk=
 github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200817153016-2ea5cbaf5ec0/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
 github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200822201400-474f4fdccc52 h1:FXtCp0ybqdQL9knb3OGDpkNTaBbPxgkqPeWKotUwkH0=
 github.com/filecoin-project/go-jsonrpc v0.1.2-0.20200822201400-474f4fdccc52/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
@@ -242,10 +246,13 @@ github.com/filecoin-project/go-multistore v0.0.3 h1:vaRBY4YiA2UZFPK57RNuewypB8u0
 github.com/filecoin-project/go-multistore v0.0.3/go.mod h1:kaNqCC4IhU4B1uyr7YWFHd23TL4KM32aChS0jNkyUvQ=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
+github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20 h1:+/4aUeUoKr6AKfPE3mBhXA5spIV6UcKdTYDPNU2Tdmg=
+github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20/go.mod h1:mPn+LRRd5gEKNAtc+r3ScpW2JRU/pj4NBKdADYWHiak=
 github.com/filecoin-project/go-paramfetch v0.0.1/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200701152213-3e0f0afdc261 h1:A256QonvzRaknIIAuWhe/M2dpV2otzs3NBhi5TWa/UA=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200701152213-3e0f0afdc261/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
+github.com/filecoin-project/go-state-types v0.0.0-20200903145444-247639ffa6ad/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4 h1:EG5midq073Dk3b1hgkjE/blVA2z9G7INKppmT5ZeCOs=
 github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df h1:m2esXSuGBkuXlRyCsl1a/7/FkFam63o1OzIgzaHtOfI=
@@ -268,6 +275,8 @@ github.com/filecoin-project/lotus v0.5.8-0.20200902130912-0962292f920e h1:ZHH2By
 github.com/filecoin-project/lotus v0.5.8-0.20200902130912-0962292f920e/go.mod h1:OkZ5aUqs+fFnJOq9243WJDsTa9c3/Ae67NIAwVhAB+0=
 github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf h1:AFhnhDF7vCRzlolb20nQWOwA9+lk4rnEMXPE2AmhwoE=
 github.com/filecoin-project/lotus v0.5.8-0.20200903221953-ada5e6ae68cf/go.mod h1:wxuzS4ozpCFThia18G+J5P0Jp/DSiq9ezzJF1yvZuP4=
+github.com/filecoin-project/lotus v0.5.11-0.20200907070510-420a8706da6d h1:5iZu++0BfeRhvkXLfyeb97QEiN2pxmwGBn4J1jEusGM=
+github.com/filecoin-project/lotus v0.5.11-0.20200907070510-420a8706da6d/go.mod h1:SVrkI6GQzqSeSuaZ6KsHih4Dh800q9HSFQCtBnyMYBI=
 github.com/filecoin-project/sector-storage v0.0.0-20200712023225-1d67dcfa3c15/go.mod h1:salgVdX7qeXFo/xaiEQE29J4pPkjn71T0kt0n+VDBzo=
 github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a h1:oDYwbXXcbMYrQX1CgYd2Zwb4ocghYw1zBctvCTW1RoE=
 github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a/go.mod h1:oOawOl9Yk+qeytLzzIryjI8iRbqo+qzS6EEeElP4PWA=
@@ -292,6 +301,8 @@ github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea h
 github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea/go.mod h1:Pr5ntAaxsh+sLG/LYiL4tKzvA83Vk5vLODYhfNwOg7k=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200730063404-f7db367e9401 h1:jLzN1hwO5WpKPu8ASbW8fs1FUCsOWNvoBXzQhv+8/E8=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200730063404-f7db367e9401/go.mod h1:Pr5ntAaxsh+sLG/LYiL4tKzvA83Vk5vLODYhfNwOg7k=
+github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
+github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
 github.com/filecoin-project/statediff v0.0.1 h1:lym6d5wNnzr+5Uc/6RRWx1hgwb+tCKn2mFIK0Eb1Q18=
 github.com/filecoin-project/statediff v0.0.1/go.mod h1:qNWauolLFEzOiA4LNWermBRVNbaZHfPcPevumZeh+hE=
 github.com/filecoin-project/storage-fsm v0.0.0-20200805013058-9d9ea4e6331f/go.mod h1:1CGbd11KkHuyWPT+xwwCol1zl/jnlpiKD2L4fzKxaiI=
@@ -300,6 +311,7 @@ github.com/filecoin-project/test-vectors v0.0.0-20200826113833-9ffe6524729d/go.m
 github.com/filecoin-project/test-vectors v0.0.0-20200901152848-cd8867c435b9/go.mod h1:bhGAdMCoLxHz2vw14BjR6iuMrWMEZ/ezyF1ri2AXwQI=
 github.com/filecoin-project/test-vectors v0.0.0-20200901185932-907892394dd8/go.mod h1:AjyLuikTxw+nwSYBflF3ndED/N7gJ2RUYbmIouD2Xtw=
 github.com/filecoin-project/test-vectors v0.0.0-20200902131127-9806d09b005d/go.mod h1:QNI4sUwq9kZSR3IJJcQAzKkSSF89lV4R2Yq2DhJ5doM=
+github.com/filecoin-project/test-vectors v0.0.0-20200903223506-84da0a5ea125/go.mod h1:Lc4OqB4cQsJVCiSKq7tC7VBRoDjgP66DEc/mlC46qgg=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
@@ -680,6 +692,8 @@ github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsimonetti/rtnetlink v0.0.0-20190830100107-3784a6c7c552/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/filecoin-project/go-paramfetch v0.0.2-0.20200701152213-3e0f0afdc261 h
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200701152213-3e0f0afdc261/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
 github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4 h1:EG5midq073Dk3b1hgkjE/blVA2z9G7INKppmT5ZeCOs=
 github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
+github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df h1:m2esXSuGBkuXlRyCsl1a/7/FkFam63o1OzIgzaHtOfI=
+github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v0.0.0-20200714194326-a77c3ae20989/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v0.0.0-20200813232949-df9b130df370 h1:Jbburj7Ih2iaJ/o5Q9A+EAeTabME6YII7FLi9SKUf5c=
@@ -283,6 +285,8 @@ github.com/filecoin-project/specs-actors v0.9.3 h1:Fi75G/UQ7R4eiIwnN+S6bBQ9LqKiv
 github.com/filecoin-project/specs-actors v0.9.3/go.mod h1:YasnVUOUha0DN5wB+twl+V8LlDKVNknRG00kTJpsfFA=
 github.com/filecoin-project/specs-actors v0.9.4 h1:FePB+hrctHHiTbmaY4hnvBJzfgckN3eJreUZWpS5yks=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
+github.com/filecoin-project/specs-actors v0.9.6 h1:U3PU4jrHcmXxfEP0CC1fGETx4RrXlm5RYJeuT5eWjhI=
+github.com/filecoin-project/specs-actors v0.9.6/go.mod h1:wM2z+kwqYgXn5Z7scV1YHLyd1Q1cy0R8HfTIWQ0BFGU=
 github.com/filecoin-project/specs-actors v0.9.7 h1:7PAZ8kdqwBdmgf/23FCkQZLCXcVu02XJrkpkhBikiA8=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea h1:iixjULRQFPn7Q9KlIqfwLJnlAXO10bbkI+xy5GKGdLY=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200622113353-88a9704877ea/go.mod h1:Pr5ntAaxsh+sLG/LYiL4tKzvA83Vk5vLODYhfNwOg7k=

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/ipfs/go-cid"
 )
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/ipfs/go-cid"
 )


### PR DESCRIPTION
Updating to go-state-types as part of refactoring of upgrade-stable types out of specs-actors.  This won't build until we update lotus. The circular dependency with lotus makes things tricky but this branch is ready to go to consume an updated lotus (missing the statediff dep). We'll then have to PR adding this version of statediff back as a dependency to lotus.