### PR TITLE
refactor: switch caller validation branch type to int64

### DIFF
--- a/gen/suites/vm_violations/caller_validation.go
+++ b/gen/suites/vm_violations/caller_validation.go
@@ -5,19 +5,21 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	typegen "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/test-vectors/chaos"
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )
 
-func callerValidation(branch *big.Int, expectedCode exitcode.ExitCode) func(v *MessageVectorBuilder) {
+func callerValidation(branch chaos.CallerValidationBranch, expectedCode exitcode.ExitCode) func(v *MessageVectorBuilder) {
 	return func(v *MessageVectorBuilder) {
 		v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
 
 		alice := v.Actors.Account(address.SECP256K1, abi.NewTokenAmount(1_000_000_000_000))
 		v.CommitPreconditions()
 
-		v.Messages.Raw(alice.ID, chaos.Address, chaos.MethodCallerValidation, MustSerialize(branch), Nonce(0), Value(big.Zero()))
+		cborBranch := typegen.CborInt(branch)
+		v.Messages.Raw(alice.ID, chaos.Address, chaos.MethodCallerValidation, MustSerialize(&cborBranch), Nonce(0), Value(big.Zero()))
 		v.CommitApplies()
 
 		v.Assert.EveryMessageResultSatisfies(ExitCode(expectedCode))

--- a/gen/suites/vm_violations/main.go
+++ b/gen/suites/vm_violations/main.go
@@ -24,7 +24,7 @@ func main() {
 				Desc:    "verifies that an actor that performs no caller validation fails",
 			},
 			Selector:    map[string]string{"chaos_actor": "true"},
-			MessageFunc: callerValidation(&chaos.CallerValidationBranchNone, exitcode.SysErrorIllegalActor),
+			MessageFunc: callerValidation(chaos.CallerValidationBranchNone, exitcode.SysErrorIllegalActor),
 		},
 		&VectorDef{
 			Metadata: &Metadata{
@@ -33,7 +33,7 @@ func main() {
 				Desc:    "verifies that an actor that validates the caller twice fails",
 			},
 			Selector:    map[string]string{"chaos_actor": "true"},
-			MessageFunc: callerValidation(&chaos.CallerValidationBranchTwice, exitcode.SysErrorIllegalActor),
+			MessageFunc: callerValidation(chaos.CallerValidationBranchTwice, exitcode.SysErrorIllegalActor),
 		},
 		&VectorDef{
 			Metadata: &Metadata{
@@ -42,7 +42,7 @@ func main() {
 				Desc:    "verifies that an actor that validates against a nil allowed address set fails",
 			},
 			Selector:    map[string]string{"chaos_actor": "true"},
-			MessageFunc: callerValidation(&chaos.CallerValidationBranchAddrNilSet, exitcode.SysErrForbidden),
+			MessageFunc: callerValidation(chaos.CallerValidationBranchAddrNilSet, exitcode.SysErrForbidden),
 		},
 		&VectorDef{
 			Metadata: &Metadata{
@@ -51,7 +51,7 @@ func main() {
 				Desc:    "verifies that an actor that validates against a nil allowed type set fails",
 			},
 			Selector:    map[string]string{"chaos_actor": "true"},
-			MessageFunc: callerValidation(&chaos.CallerValidationBranchTypeNilSet, exitcode.SysErrForbidden),
+			MessageFunc: callerValidation(chaos.CallerValidationBranchTypeNilSet, exitcode.SysErrForbidden),
 		},
 	)
 


### PR DESCRIPTION
Also changed `MutateStateBranch` for consistency.

resolves https://github.com/filecoin-project/test-vectors/issues/84