### PR TITLE
fix tipset ApplicableMessage ordering

### DIFF
--- a/gen/builders/tipsets.go
+++ b/gen/builders/tipsets.go
@@ -54,7 +54,7 @@ func (tss *TipsetSeq) All() []*Tipset {
 // Messages returns all ApplicableMessages that have been included in blocks,
 // in no particular order.
 func (tss *TipsetSeq) Messages() []*ApplicableMessage {
-	msgs := make([]*ApplicableMessage, 0, len(tss.msgIdx))
+	msgs := make([]*ApplicableMessage, 0, len(tss.orderedMsgs))
 	for _, msg := range tss.orderedMsgs {
 		msgs = append(msgs, msg)
 	}

--- a/gen/builders/tipsets.go
+++ b/gen/builders/tipsets.go
@@ -54,10 +54,8 @@ func (tss *TipsetSeq) All() []*Tipset {
 // Messages returns all ApplicableMessages that have been included in blocks,
 // in no particular order.
 func (tss *TipsetSeq) Messages() []*ApplicableMessage {
-	msgs := make([]*ApplicableMessage, 0, len(tss.orderedMsgs))
-	for _, msg := range tss.orderedMsgs {
-		msgs = append(msgs, msg)
-	}
+	msgs := make([]*ApplicableMessage, len(tss.orderedMsgs))
+	copy(msgs, tss.orderedMsgs)
 	return msgs
 }
 

--- a/gen/builders/tipsets.go
+++ b/gen/builders/tipsets.go
@@ -52,7 +52,7 @@ func (tss *TipsetSeq) All() []*Tipset {
 }
 
 // Messages returns all ApplicableMessages that have been included in blocks,
-// in no particular order.
+// ordered based on inclusion in the tipset.
 func (tss *TipsetSeq) Messages() []*ApplicableMessage {
 	msgs := make([]*ApplicableMessage, len(tss.orderedMsgs))
 	copy(msgs, tss.orderedMsgs)


### PR DESCRIPTION
At the moment some tests (such as https://github.com/filecoin-project/test-vectors/blob/master/gen/suites/reward/main.go#L149-L150) expect `v.Tipsets.Messages()` to return messages in the sequence they have been applied.

However `v.Tipsets.Messages()` is ranging over a map, so it returns a non-deterministic sequence when called, which results in flaky test.

---

This PR is adding additional slice for ApplicableMessage within a Tipset, which records the sequence with which messages have been added to a tipset. As far as I understand, the sequence with which we add blocks to the tipset in our test vectors, is the same sequence with which blocks will actually be applied.