### PR TITLE
test: runtime Caller() and Receiver() return ID addresses

### DIFF
--- a/gen/suites/vm_violations/caller_validation.go
+++ b/gen/suites/vm_violations/caller_validation.go
@@ -5,23 +5,86 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
-	typegen "github.com/whyrusleeping/cbor-gen"
-
 	"github.com/filecoin-project/lotus/conformance/chaos"
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )
 
-func callerValidation(branch chaos.CallerValidationBranch, expectedCode exitcode.ExitCode) func(v *MessageVectorBuilder) {
+func callerValidation(buildArgs func() chaos.CallerValidationArgs, expectedCode exitcode.ExitCode) func(v *MessageVectorBuilder) {
 	return func(v *MessageVectorBuilder) {
 		v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
 
 		alice := v.Actors.Account(address.SECP256K1, abi.NewTokenAmount(1_000_000_000_000))
 		v.CommitPreconditions()
 
-		cborBranch := typegen.CborInt(branch)
-		v.Messages.Raw(alice.ID, chaos.Address, chaos.MethodCallerValidation, MustSerialize(&cborBranch), Nonce(0), Value(big.Zero()))
+		args := buildArgs()
+		v.Messages.Raw(alice.ID, chaos.Address, chaos.MethodCallerValidation, MustSerialize(&args), Nonce(0), Value(big.Zero()))
 		v.CommitApplies()
 
 		v.Assert.EveryMessageResultSatisfies(ExitCode(expectedCode))
 	}
+}
+
+func robustCallerValidation(v *MessageVectorBuilder) {
+	v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
+
+	alice := v.Actors.Account(address.SECP256K1, abi.NewTokenAmount(1_000_000_000_000))
+	v.CommitPreconditions()
+
+	// send from robust address, allowing ID address - should succeed
+	from := alice.Robust
+	args := chaos.CallerValidationArgs{Branch: chaos.CallerValidationBranchIs, Addrs: []address.Address{alice.ID}}
+
+	v.Messages.Raw(from, chaos.Address, chaos.MethodCallerValidation, MustSerialize(&args), Nonce(0), Value(big.Zero()))
+	v.CommitApplies()
+
+	v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.Ok))
+}
+
+func robustReceiverValidation(v *MessageVectorBuilder) {
+	v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
+
+	initial := int64(1_000_000_000_000)
+	alice := v.Actors.Account(address.SECP256K1, abi.NewTokenAmount(initial))
+
+	// setup a robust address for chaos
+	chaosRobustAddr := v.Wallet.NewSECP256k1Account()
+	chaosIDAddr, err := v.StateTracker.StateTree.RegisterNewAddress(chaosRobustAddr)
+	v.Assert.NoError(err)
+
+	err = v.StateTracker.StateTree.SetActor(chaosIDAddr, v.StateTracker.Header(chaos.Address))
+	v.Assert.NoError(err)
+
+	v.CommitPreconditions()
+
+	// Verify that Runtime.Message().Caller() returns ID address:
+	// Send from alice's robust address, allowing her ID address. Should succeed
+	// if Runtime.Message().Caller() returns ID addresses.
+	args := chaos.CallerValidationArgs{Branch: chaos.CallerValidationBranchIs, Addrs: []address.Address{alice.ID}}
+	// ...also send some fil here to allow chaos to send a message to itself afterwards.
+	m0 := v.Messages.Raw(alice.Robust, chaosIDAddr, chaos.MethodCallerValidation, MustSerialize(&args), Nonce(0), Value(big.NewInt(initial/2)))
+
+	// Verify that Runtime.Message().Receiver() returns an ID address:
+	// Tell chaos to send a message to its (robust) self, calling
+	// CallerValidation method, using the branch that validates that the caller
+	// IS the receiver. We've already verified above that
+	// Runtime.Message().Caller() returns ID addresses, so provided
+	// Runtime.Message().Receiver() returns an ID address, not a robust
+	// address, then this should work.
+	m1 := v.Messages.Typed(alice.ID, chaosIDAddr, ChaosSend(&chaos.SendArgs{
+		To:     chaosRobustAddr,
+		Value:  big.Zero(),
+		Method: chaos.MethodCallerValidation,
+		Params: MustSerialize(&chaos.CallerValidationArgs{Branch: chaos.CallerValidationBranchIsReceiver}),
+	}), Nonce(1), Value(big.Zero()))
+
+	v.CommitApplies()
+
+	v.Assert.ExitCodeEq(m0.Result.ExitCode, exitcode.Ok)
+	v.Assert.ExitCodeEq(m1.Result.ExitCode, exitcode.Ok)
+
+	var chaosRet chaos.SendReturn
+	MustDeserialize(m1.Result.MessageReceipt.Return, &chaosRet)
+
+	// The inner message should succeed.
+	v.Assert.ExitCodeEq(chaosRet.Code, exitcode.Ok)
 }

--- a/gen/suites/vm_violations/main.go
+++ b/gen/suites/vm_violations/main.go
@@ -24,8 +24,10 @@ func main() {
 				Version: "v1",
 				Desc:    "verifies that an actor that performs no caller validation fails",
 			},
-			Selector:    map[string]string{"chaos_actor": "true"},
-			MessageFunc: callerValidation(chaos.CallerValidationBranchNone, exitcode.SysErrorIllegalActor),
+			Selector: map[string]string{"chaos_actor": "true"},
+			MessageFunc: callerValidation(func() chaos.CallerValidationArgs {
+				return chaos.CallerValidationArgs{Branch: chaos.CallerValidationBranchNone}
+			}, exitcode.SysErrorIllegalActor),
 		},
 		&VectorDef{
 			Metadata: &Metadata{
@@ -33,8 +35,10 @@ func main() {
 				Version: "v1",
 				Desc:    "verifies that an actor that validates the caller twice fails",
 			},
-			Selector:    map[string]string{"chaos_actor": "true"},
-			MessageFunc: callerValidation(chaos.CallerValidationBranchTwice, exitcode.SysErrorIllegalActor),
+			Selector: map[string]string{"chaos_actor": "true"},
+			MessageFunc: callerValidation(func() chaos.CallerValidationArgs {
+				return chaos.CallerValidationArgs{Branch: chaos.CallerValidationBranchTwice}
+			}, exitcode.SysErrorIllegalActor),
 		},
 		&VectorDef{
 			Metadata: &Metadata{
@@ -42,8 +46,25 @@ func main() {
 				Version: "v1",
 				Desc:    "verifies that an actor that validates against a nil allowed address set fails",
 			},
-			Selector:    map[string]string{"chaos_actor": "true"},
-			MessageFunc: callerValidation(chaos.CallerValidationBranchAddrNilSet, exitcode.SysErrForbidden),
+			Selector: map[string]string{"chaos_actor": "true"},
+			MessageFunc: callerValidation(func() chaos.CallerValidationArgs {
+				return chaos.CallerValidationArgs{Branch: chaos.CallerValidationBranchIs}
+			}, exitcode.SysErrForbidden),
+		},
+		&VectorDef{
+			Metadata: &Metadata{
+				ID:      "fails-incorrect-caller-addr",
+				Version: "v1",
+				Desc:    "verifies that an actor that validates against an address set that does not include the caller addr fails",
+			},
+			Selector: map[string]string{"chaos_actor": "true"},
+			MessageFunc: callerValidation(func() chaos.CallerValidationArgs {
+				return chaos.CallerValidationArgs{
+					Branch: chaos.CallerValidationBranchIs,
+					// caller address will be a brand new account NOT the system actor address
+					Addrs: []address.Address{builtin.SystemActorAddr},
+				}
+			}, exitcode.SysErrForbidden),
 		},
 		&VectorDef{
 			Metadata: &Metadata{
@@ -51,8 +72,46 @@ func main() {
 				Version: "v1",
 				Desc:    "verifies that an actor that validates against a nil allowed type set fails",
 			},
+			Selector: map[string]string{"chaos_actor": "true"},
+			MessageFunc: callerValidation(func() chaos.CallerValidationArgs {
+				return chaos.CallerValidationArgs{Branch: chaos.CallerValidationBranchType}
+			}, exitcode.SysErrForbidden),
+		},
+		&VectorDef{
+			Metadata: &Metadata{
+				ID:      "fails-incorrect-caller-type",
+				Version: "v1",
+				Desc:    "verifies that an actor that validates against a actor type set that does not include the caller type",
+			},
+			Selector: map[string]string{"chaos_actor": "true"},
+			MessageFunc: callerValidation(func() chaos.CallerValidationArgs {
+				return chaos.CallerValidationArgs{
+					Branch: chaos.CallerValidationBranchIs,
+					// caller will be of type account actor NOT system actor
+					Types: []cid.Cid{builtin.SystemActorCodeID},
+				}
+			}, exitcode.SysErrForbidden),
+		},
+		&VectorDef{
+			Metadata: &Metadata{
+				ID:      "succeeds-caller-robust-address-allowed-id-address",
+				Version: "v1",
+				Desc:    "a caller using a robust address is successfully verified against an ID address list",
+			},
 			Selector:    map[string]string{"chaos_actor": "true"},
-			MessageFunc: callerValidation(chaos.CallerValidationBranchTypeNilSet, exitcode.SysErrForbidden),
+			MessageFunc: robustCallerValidation,
+		},
+		&VectorDef{
+			Metadata: &Metadata{
+				ID:      "succeeds-receiver-robust-address-allowed-id-address",
+				Version: "v1",
+				Desc:    "a receiver via a robust address is successfully verified against an ID address list",
+				Comment: "the call to Runtime.Message().Receiver() should return an ID address but returns the robust address that the message was sent to, fixed by https://github.com/filecoin-project/lotus/pull/3589",
+			},
+			Selector:    map[string]string{"chaos_actor": "true"},
+			Mode:        ModeLenientAssertions,
+			Hints:       []string{schema.HintIncorrect, schema.HintNegate},
+			MessageFunc: robustReceiverValidation,
 		},
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc
-	github.com/filecoin-project/lotus v0.7.1-0.20200914110614-3a34856dfe30
+	github.com/filecoin-project/lotus v0.7.1-0.20200915131020-ca047abecd65
 	github.com/filecoin-project/specs-actors v0.9.8
 	github.com/filecoin-project/test-vectors/schema v0.0.1
 	github.com/ipfs/go-block-format v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,10 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
+github.com/filecoin-project/lotus v0.7.1-0.20200914110614-3a34856dfe30 h1:L+2Yyq1rDiCw2qrIdDSu+Q0jMTtD5X1Tvfo0JxzgyCg=
+github.com/filecoin-project/lotus v0.7.1-0.20200914110614-3a34856dfe30/go.mod h1:zhkw4+m299fUtbhhSwLHEWsT2oAdrDRD3cs5scIzfAM=
+github.com/filecoin-project/lotus v0.7.1-0.20200915131020-ca047abecd65 h1:1rpx1bR9E+caEjP1+uV3/vtMTjFZeTYtk/aKrxdg4xA=
+github.com/filecoin-project/lotus v0.7.1-0.20200915131020-ca047abecd65/go.mod h1:zhkw4+m299fUtbhhSwLHEWsT2oAdrDRD3cs5scIzfAM=
 github.com/filecoin-project/specs-actors v0.9.4 h1:FePB+hrctHHiTbmaY4hnvBJzfgckN3eJreUZWpS5yks=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.7 h1:7PAZ8kdqwBdmgf/23FCkQZLCXcVu02XJrkpkhBikiA8=


### PR DESCRIPTION
This PR adds vectors to assert that `Caller()` and `Receiver()` always return ID addresses. It does this using the `CallerValidation` method of the chaos actor, which has been altered slightly to accept validation addresses and type CIDs and has a new branch that validates the caller is the receiver (internal sends).

It means we can test `Caller()` and `Receiver()` always return ID addresses by simply sending messages to _robust_ addresses, passing the ID addresses and checking the validation passes or not.

Depends on:

* [ ] https://github.com/filecoin-project/lotus/pull/3857

Confirmed that the following PR fixes the vector that is broken:

* https://github.com/filecoin-project/lotus/pull/3589

resolves #128