### PR TITLE
test: runtime Caller() and Receiver() always return ID addresses

### DIFF
--- a/gen/builders/actors.go
+++ b/gen/builders/actors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/lotus/chain/types"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -12,7 +13,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/account"
 	"github.com/filecoin-project/specs-actors/actors/builtin/miner"
 	"github.com/filecoin-project/specs-actors/actors/builtin/power"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/go-address"
@@ -205,7 +205,7 @@ func (a *Actors) Miner(cfg MinerActorCfg) Miner {
 
 	// add claim for the miner
 	// TODO: allow caller to specify.
-	err = hm.Put(adt.AddrKey(handle.ID), &power.Claim{
+	err = hm.Put(abi.AddrKey(handle.ID), &power.Claim{
 		RawBytePower:    abi.NewStoragePower(0),
 		QualityAdjPower: abi.NewStoragePower(0),
 	})
@@ -250,7 +250,7 @@ func (a *Actors) MinerN(cfg MinerActorCfg, miners ...*Miner) {
 
 // CreateActor creates an actor in the state tree, of the specified kind, with
 // the specified address and balance, and sets its state to the supplied state.
-func (a *Actors) CreateActor(code cid.Cid, addr address.Address, balance abi.TokenAmount, state runtime.CBORMarshaler) AddressHandle {
+func (a *Actors) CreateActor(code cid.Cid, addr address.Address, balance abi.TokenAmount, state cbor.Marshaler) AddressHandle {
 	var id address.Address
 	if addr.Protocol() != address.ID {
 		var err error

--- a/gen/builders/state_zero.go
+++ b/gen/builders/state_zero.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/builtin/account"
 	"github.com/filecoin-project/specs-actors/actors/builtin/cron"
@@ -15,7 +16,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
 	"github.com/filecoin-project/specs-actors/actors/builtin/system"
 	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
 	"github.com/filecoin-project/go-address"
@@ -23,6 +23,7 @@ import (
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/lotus/conformance/chaos"
+
 	"github.com/filecoin-project/test-vectors/schema"
 )
 
@@ -59,7 +60,7 @@ func (st *StateTracker) initializeZeroState(selector schema.Selector) {
 		Addr    address.Address
 		Balance abi.TokenAmount
 		Code    cid.Cid
-		State   runtime.CBORMarshaler
+		State   cbor.Marshaler
 	}
 
 	var actors []ActorState

--- a/gen/suites/nested/nested.go
+++ b/gen/suites/nested/nested.go
@@ -6,16 +6,17 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	"github.com/filecoin-project/specs-actors/actors/builtin/reward"
-	"github.com/filecoin-project/specs-actors/actors/runtime"
 	typegen "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/lotus/conformance/chaos"
+
 	. "github.com/filecoin-project/test-vectors/gen/builders"
 )
 
@@ -345,7 +346,7 @@ func prepareStage(v *MessageVectorBuilder, creatorBalance, msBalance abi.TokenAm
 	}
 }
 
-func (s *msStage) sendOk(to address.Address, value abi.TokenAmount, method abi.MethodNum, params runtime.CBORMarshaler, approverNonce uint64) *ApplicableMessage {
+func (s *msStage) sendOk(to address.Address, value abi.TokenAmount, method abi.MethodNum, params cbor.Marshaler, approverNonce uint64) *ApplicableMessage {
 	buf := bytes.Buffer{}
 	if params != nil {
 		err := params.MarshalCBOR(&buf)

--- a/gen/suites/reward/main.go
+++ b/gen/suites/reward/main.go
@@ -104,7 +104,7 @@ func main() {
 				v.StagedMessages.ApplyN(v.StagedMessages.All()...)
 
 				// penalty is non-zero.
-				v.Assert.Greater(msg.Result.Penalty.Uint64(), uint64(0))
+				v.Assert.Greater(msg.Result.GasCosts.MinerPenalty.Uint64(), uint64(0))
 			}, nil),
 		},
 		&VectorDef{
@@ -123,7 +123,7 @@ func main() {
 				v.StagedMessages.Sugar().Transfer(from, to, Value(bal), Nonce(0))
 			}, func(v *TipsetVectorBuilder) {
 				// penalty is zero.
-				v.Assert.Zero(v.Tipsets.Messages()[0].Result.Penalty.Uint64())
+				v.Assert.Zero(v.Tipsets.Messages()[0].Result.GasCosts.MinerPenalty.Uint64())
 			}),
 		},
 		&VectorDef{
@@ -148,7 +148,7 @@ func main() {
 				msgs := v.Tipsets.Messages()
 				v.Assert.Equal(exitcode.Ok, msgs[0].Result.ExitCode)             // first msg ok
 				v.Assert.Equal(exitcode.SysErrOutOfGas, msgs[1].Result.ExitCode) // second msg fail
-				v.Assert.Zero(v.Tipsets.Messages()[0].Result.Penalty.Uint64())   // no penalties levied
+				v.Assert.Zero(v.Tipsets.Messages()[0].Result.GasCosts.MinerPenalty.Uint64()) // no penalties levied
 			}),
 		},
 	)

--- a/gen/suites/reward/penalties.go
+++ b/gen/suites/reward/penalties.go
@@ -60,10 +60,10 @@ func minerPenalized(minerCnt int, messageFn func(v *TipsetVectorBuilder), checks
 			burntGas      = big.Zero()
 		)
 		for _, am := range v.Tipsets.Messages() {
-			penalty := am.Result.Penalty
+			penalty := am.Result.GasCosts.MinerPenalty
 			cumPenalty = big.Sum(cumPenalty, penalty)
 
-			tip := am.Result.MinerTip
+			tip := am.Result.GasCosts.MinerTip
 			v.Assert.Equal(GetMinerReward(am), tip)
 			firstMinerTip = big.Sum(firstMinerTip, tip)
 

--- a/gen/suites/vm_violations/main.go
+++ b/gen/suites/vm_violations/main.go
@@ -297,4 +297,28 @@ func main() {
 	}
 
 	g.Group("actor_abort", actorAbortVectors...)
+
+	g.Group("runtime_inspections",
+		&VectorDef{
+			Metadata: &Metadata{
+				ID:      "caller-always-id-address",
+				Version: "v1",
+				Desc:    "verify Runtime.Caller() returns an ID address even when message is sent from a robust address",
+			},
+			Selector:    map[string]string{"chaos_actor": "true"},
+			MessageFunc: callerAlwaysIDAddress,
+		},
+		&VectorDef{
+			Metadata: &Metadata{
+				ID:      "receiver-always-id-address",
+				Version: "v1",
+				Desc:    "verify Runtime.Receiver() returns an ID address even when message is sent to a robust address",
+				Comment: "the call to Runtime.Receiver() should return an ID address but returns the robust address that the message was sent to, fixed by https://github.com/filecoin-project/lotus/pull/3589",
+			},
+			Selector:    map[string]string{"chaos_actor": "true"},
+			Mode:        ModeLenientAssertions,
+			Hints:       []string{schema.HintIncorrect, schema.HintNegate},
+			MessageFunc: receiverAlwaysIDAddress,
+		},
+	)
 }

--- a/gen/suites/vm_violations/runtime_inspections.go
+++ b/gen/suites/vm_violations/runtime_inspections.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/lotus/conformance/chaos"
+
+	. "github.com/filecoin-project/test-vectors/gen/builders"
+)
+
+func callerAlwaysIDAddress(v *MessageVectorBuilder) {
+	v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
+
+	alice := v.Actors.Account(address.SECP256K1, abi.NewTokenAmount(1_000_000_000_000))
+	v.CommitPreconditions()
+
+	msg := v.Messages.Raw(alice.Robust, chaos.Address, chaos.MethodInspectRuntime, []byte{}, Nonce(0), Value(big.Zero()))
+	v.CommitApplies()
+
+	var rt chaos.InspectRuntimeReturn
+	MustDeserialize(msg.Result.Return, &rt)
+
+	v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.Ok))
+	v.Assert.Equal(alice.ID, rt.Caller)
+}
+
+func receiverAlwaysIDAddress(v *MessageVectorBuilder) {
+	v.Messages.SetDefaults(GasLimit(1_000_000_000), GasPremium(1), GasFeeCap(200))
+
+	alice := v.Actors.Account(address.SECP256K1, abi.NewTokenAmount(1_000_000_000_000))
+
+	// setup a robust address for chaos
+	chaosRobustAddr := v.Wallet.NewSECP256k1Account()
+	chaosIDAddr, err := v.StateTracker.StateTree.RegisterNewAddress(chaosRobustAddr)
+	v.Assert.NoError(err)
+
+	err = v.StateTracker.StateTree.SetActor(chaosIDAddr, v.StateTracker.Header(chaos.Address))
+	v.Assert.NoError(err)
+
+	v.CommitPreconditions()
+
+	msg := v.Messages.Raw(alice.ID, chaosRobustAddr, chaos.MethodInspectRuntime, []byte{}, Nonce(0), Value(big.Zero()))
+	v.CommitApplies()
+
+	var rt chaos.InspectRuntimeReturn
+	MustDeserialize(msg.Result.Return, &rt)
+
+	v.Assert.EveryMessageResultSatisfies(ExitCode(exitcode.Ok))
+	v.Assert.Equal(chaosIDAddr, rt.Receiver)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc
-	github.com/filecoin-project/lotus v0.7.1-0.20200914110614-3a34856dfe30
-	github.com/filecoin-project/specs-actors v0.9.8
+	github.com/filecoin-project/lotus v0.7.1-0.20200915212409-ed4caac9bff5
+	github.com/filecoin-project/specs-actors v0.9.10
 	github.com/filecoin-project/test-vectors/schema v0.0.1
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/filecoin-project/go-bitfield v0.2.0
 	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc
-	github.com/filecoin-project/lotus v0.7.1-0.20200915212409-ed4caac9bff5
+	github.com/filecoin-project/lotus v0.7.1-0.20200916145008-5a8ee0dd2af6
 	github.com/filecoin-project/specs-actors v0.9.10
 	github.com/filecoin-project/test-vectors/schema v0.0.1
 	github.com/ipfs/go-block-format v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -228,7 +228,6 @@ github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4 h1
 github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df h1:m2esXSuGBkuXlRyCsl1a/7/FkFam63o1OzIgzaHtOfI=
 github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
-github.com/filecoin-project/go-state-types v0.0.0-20200909080127-001afaca718c/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc h1:1vr/LoqGq5m5g37Q3sNSAjfwF1uJY0zmiHcvnxY6hik=
 github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-statemachine v0.0.0-20200714194326-a77c3ae20989/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -238,14 +237,12 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
-github.com/filecoin-project/lotus v0.7.1-0.20200914110614-3a34856dfe30/go.mod h1:zhkw4+m299fUtbhhSwLHEWsT2oAdrDRD3cs5scIzfAM=
-github.com/filecoin-project/lotus v0.7.1-0.20200915212409-ed4caac9bff5 h1:aAjPg7ZOz6OZWsRRSAJ5R0VNJf7StjvpmtwHVymOyL4=
-github.com/filecoin-project/lotus v0.7.1-0.20200915212409-ed4caac9bff5/go.mod h1:T0of9kQi1A3OgJie3jEaBhJnYcwkFqHORK5OpIR/HO8=
+github.com/filecoin-project/lotus v0.7.1-0.20200916145008-5a8ee0dd2af6 h1:4WsIJgfPJvwhbJo7OfQIrZcXTYDwBJuk5fjvQgTNn50=
+github.com/filecoin-project/lotus v0.7.1-0.20200916145008-5a8ee0dd2af6/go.mod h1:T0of9kQi1A3OgJie3jEaBhJnYcwkFqHORK5OpIR/HO8=
 github.com/filecoin-project/specs-actors v0.9.4 h1:FePB+hrctHHiTbmaY4hnvBJzfgckN3eJreUZWpS5yks=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.7 h1:7PAZ8kdqwBdmgf/23FCkQZLCXcVu02XJrkpkhBikiA8=
 github.com/filecoin-project/specs-actors v0.9.7/go.mod h1:wM2z+kwqYgXn5Z7scV1YHLyd1Q1cy0R8HfTIWQ0BFGU=
-github.com/filecoin-project/specs-actors v0.9.8/go.mod h1:xFObDoWPySBNTNBrGXVVrutmgSZH/mMo46Q1bec/0hw=
 github.com/filecoin-project/specs-actors v0.9.10 h1:gU0TrRhgkCsBEOP42sGDE7RQuR0Cov9hJhBqq+RJmjU=
 github.com/filecoin-project/specs-actors v0.9.10/go.mod h1:czlvLQGEX0fjLLfdNHD7xLymy6L3n7aQzRWzsYGf+ys=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=

--- a/go.sum
+++ b/go.sum
@@ -228,7 +228,6 @@ github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4 h1
 github.com/filecoin-project/go-state-types v0.0.0-20200904021452-1883f36ca2f4/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df h1:m2esXSuGBkuXlRyCsl1a/7/FkFam63o1OzIgzaHtOfI=
 github.com/filecoin-project/go-state-types v0.0.0-20200905071437-95828685f9df/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
-github.com/filecoin-project/go-state-types v0.0.0-20200909080127-001afaca718c h1:HHRMFpU8OrODDUja5NmGWNBAVGoSy4MRjxgZa+a0qIw=
 github.com/filecoin-project/go-state-types v0.0.0-20200909080127-001afaca718c/go.mod h1:IQ0MBPnonv35CJHtWSN3YY1Hz2gkPru1Q9qoaYLxx9I=
 github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc h1:1vr/LoqGq5m5g37Q3sNSAjfwF1uJY0zmiHcvnxY6hik=
 github.com/filecoin-project/go-state-types v0.0.0-20200911004822-964d6c679cfc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
@@ -239,12 +238,16 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
+github.com/filecoin-project/lotus v0.7.1-0.20200914110614-3a34856dfe30/go.mod h1:zhkw4+m299fUtbhhSwLHEWsT2oAdrDRD3cs5scIzfAM=
+github.com/filecoin-project/lotus v0.7.1-0.20200915212409-ed4caac9bff5 h1:aAjPg7ZOz6OZWsRRSAJ5R0VNJf7StjvpmtwHVymOyL4=
+github.com/filecoin-project/lotus v0.7.1-0.20200915212409-ed4caac9bff5/go.mod h1:T0of9kQi1A3OgJie3jEaBhJnYcwkFqHORK5OpIR/HO8=
 github.com/filecoin-project/specs-actors v0.9.4 h1:FePB+hrctHHiTbmaY4hnvBJzfgckN3eJreUZWpS5yks=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.7 h1:7PAZ8kdqwBdmgf/23FCkQZLCXcVu02XJrkpkhBikiA8=
 github.com/filecoin-project/specs-actors v0.9.7/go.mod h1:wM2z+kwqYgXn5Z7scV1YHLyd1Q1cy0R8HfTIWQ0BFGU=
-github.com/filecoin-project/specs-actors v0.9.8 h1:45fnx/BsseFL3CtvSoR6CszFY26TFtsh9AHwCW2vkg8=
 github.com/filecoin-project/specs-actors v0.9.8/go.mod h1:xFObDoWPySBNTNBrGXVVrutmgSZH/mMo46Q1bec/0hw=
+github.com/filecoin-project/specs-actors v0.9.10 h1:gU0TrRhgkCsBEOP42sGDE7RQuR0Cov9hJhBqq+RJmjU=
+github.com/filecoin-project/specs-actors v0.9.10/go.mod h1:czlvLQGEX0fjLLfdNHD7xLymy6L3n7aQzRWzsYGf+ys=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796 h1:dJsTPWpG2pcTeojO2pyn0c6l+x/3MZYCBgo/9d11JEk=
 github.com/filecoin-project/specs-storage v0.1.1-0.20200907031224-ed2e5cd13796/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=


### PR DESCRIPTION
Uses the new chaos `InspectRuntime` method to test that `Caller()` and `Receiver()` always return an ID address not a robust address.

Depends on:

* [x] https://github.com/filecoin-project/lotus/pull/3861

Confirmed that the following PR fixes the vector that is broken:

* https://github.com/filecoin-project/lotus/pull/3589

resolves #128 