### PR TITLE
schema: add preconditions/circ_supply.

### DIFF
--- a/gen/builders/builder_message.go
+++ b/gen/builders/builder_message.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/lotus/chain/types"
+
 	"github.com/filecoin-project/test-vectors/schema"
 )
 
@@ -67,6 +69,14 @@ func MessageVector(metadata *schema.Metadata, selector schema.Selector, mode Mod
 	bc.Assert.enterStage(StagePreconditions)
 
 	return b
+}
+
+// SetCirculatingSupply sets the circulating supply for this vector. If not set,
+// the driver should use the total maximum supply of Filecoin as specified in
+// the protocol when executing these messages.
+func (b *MessageVectorBuilder) SetCirculatingSupply(supply abi.TokenAmount) {
+	v := supply.Int64()
+	b.vector.Pre.CircSupply = &v
 }
 
 // CommitPreconditions flushes the state tree, recording the new CID in the

--- a/gen/suites/reward/main.go
+++ b/gen/suites/reward/main.go
@@ -146,8 +146,8 @@ func main() {
 				v.StagedMessages.Typed(from, to, MinerControlAddresses(nil), Nonce(1), GasLimit(msg.Result.GasUsed-1))
 			}, func(v *TipsetVectorBuilder) {
 				msgs := v.Tipsets.Messages()
-				v.Assert.Equal(exitcode.Ok, msgs[0].Result.ExitCode)             // first msg ok
-				v.Assert.Equal(exitcode.SysErrOutOfGas, msgs[1].Result.ExitCode) // second msg fail
+				v.Assert.Equal(exitcode.Ok, msgs[0].Result.ExitCode)                         // first msg ok
+				v.Assert.Equal(exitcode.SysErrOutOfGas, msgs[1].Result.ExitCode)             // second msg fail
 				v.Assert.Zero(v.Tipsets.Messages()[0].Result.GasCosts.MinerPenalty.Uint64()) // no penalties levied
 			}),
 		},

--- a/schema.json
+++ b/schema.json
@@ -125,6 +125,9 @@
         "epoch": {
           "type": "integer"
         },
+        "circ_supply": {
+          "type": "number"
+        },
         "state_tree": {
           "title": "state tree to seed",
           "description": "state tree to seed before applying this test vector; mapping of actor addresses => serialized state",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -71,8 +71,15 @@ type Base64EncodedBytes []byte
 type Preconditions struct {
 	// Epoch must be interpreted by the driver as an abi.ChainEpoch in Lotus, or
 	// equivalent type in other implementations.
-	Epoch     int64      `json:"epoch"`
-	StateTree *StateTree `json:"state_tree"`
+	Epoch     int64      `json:"epoch,omitempty"`
+	StateTree *StateTree `json:"state_tree,omitempty"`
+
+	// CircSupply is optional. If specified, it is the value that will be
+	// injected in the VM when running this vector. If absent, the default
+	// value will be injected (TotalFilecoin, the maximum supply of Filecoin
+	// that will ever exist). It is usually odd to set it, and it's only here
+	// for specialized vectors.
+	CircSupply *int64 `json:"circ_supply,omitempty"`
 }
 
 // Receipt represents a receipt to match against.
@@ -93,12 +100,12 @@ type Postconditions struct {
 }
 
 // MarshalJSON implements json.Marshal for Base64EncodedBytes
-func (beb Base64EncodedBytes) MarshalJSON() ([]byte, error) {
-	return json.Marshal(base64.StdEncoding.EncodeToString(beb))
+func (b Base64EncodedBytes) MarshalJSON() ([]byte, error) {
+	return json.Marshal(base64.StdEncoding.EncodeToString(b))
 }
 
 // UnmarshalJSON implements json.Unmarshal for Base64EncodedBytes
-func (beb *Base64EncodedBytes) UnmarshalJSON(v []byte) error {
+func (b *Base64EncodedBytes) UnmarshalJSON(v []byte) error {
 	var s string
 	if err := json.Unmarshal(v, &s); err != nil {
 		return err
@@ -108,7 +115,7 @@ func (beb *Base64EncodedBytes) UnmarshalJSON(v []byte) error {
 	if err != nil {
 		return err
 	}
-	*beb = bytes
+	*b = bytes
 	return nil
 }
 


### PR DESCRIPTION
In extracted vectors, the circulating supply is set to the value that was in force on chain as returned by `api.StateCirculatingSupply()` at the message inclusion tipset.

In generated message-class vectors, users can set the circulating supply using `v.SetCirculatingSupply()`. If not set, the driver falls back to the total ever Filecoin in existence.