### PR TITLE
schema: add preconditions/basefee + remove blockseq wip types

### DIFF
--- a/gen/builders/builder_message.go
+++ b/gen/builders/builder_message.go
@@ -75,8 +75,13 @@ func MessageVector(metadata *schema.Metadata, selector schema.Selector, mode Mod
 // the driver should use the total maximum supply of Filecoin as specified in
 // the protocol when executing these messages.
 func (b *MessageVectorBuilder) SetCirculatingSupply(supply abi.TokenAmount) {
-	v := supply.Int64()
-	b.vector.Pre.CircSupply = &v
+	b.vector.Pre.CircSupply = supply.Int
+}
+
+// SetBaseFee sets the base fee for this vector. If not set, the driver should
+// use 100 attoFIL as the base fee when executing this vector.
+func (b *MessageVectorBuilder) SetBaseFee(basefee abi.TokenAmount) {
+	b.vector.Pre.BaseFee = basefee.Int
 }
 
 // CommitPreconditions flushes the state tree, recording the new CID in the

--- a/schema.json
+++ b/schema.json
@@ -128,6 +128,9 @@
         "circ_supply": {
           "type": "number"
         },
+        "basefee": {
+          "type": "number"
+        },
         "state_tree": {
           "title": "state tree to seed",
           "description": "state tree to seed before applying this test vector; mapping of actor addresses => serialized state",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
@@ -68,31 +67,23 @@ type StateTree struct {
 // Base64EncodedBytes is a base64-encoded binary value.
 type Base64EncodedBytes []byte
 
-// ChainHead represents a head tipset.
-type ChainHead []cid.Cid
-
-// PreconditionsBlockSeq are the preconditions for a blockseq vector.
-type PreconditionsBlockSeq struct {
-	GenesisTs time.Time  `json:"genesis_ts,omitempty"`
-	ChainHead *ChainHead `json:"chain_head,omitempty"`
-}
-
 // Preconditions contain the environment that needs to be set before the
 // vector's applies are applied.
 type Preconditions struct {
-	*PreconditionsBlockSeq
-
 	// Epoch must be interpreted by the driver as an abi.ChainEpoch in Lotus, or
 	// equivalent type in other implementations.
 	Epoch     int64      `json:"epoch,omitempty"`
 	StateTree *StateTree `json:"state_tree,omitempty"`
 
+	// BaseFee is an optional base fee to inject into the VM when feeding this
+	// message. If absent, it defaults to 100 attoFIL.
+	BaseFee *big.Int `json:"basefee,omitempty"`
 	// CircSupply is optional. If specified, it is the value that will be
-	// injected in the VM when running this vector. If absent, the default
+	// injected in the VM when feeding this message. If absent, the default
 	// value will be injected (TotalFilecoin, the maximum supply of Filecoin
 	// that will ever exist). It is usually odd to set it, and it's only here
 	// for specialized vectors.
-	CircSupply *int64 `json:"circ_supply,omitempty"`
+	CircSupply *big.Int `json:"circ_supply,omitempty"`
 }
 
 // Receipt represents a receipt to match against.
@@ -138,51 +129,6 @@ type Diagnostics struct {
 	Data   Base64EncodedBytes `json:"data"`
 }
 
-// OffsetMillis is a type that serializes as uint64 in json, and represents a
-// duration in milliseconds.
-type OffsetMillis struct {
-	time.Duration
-}
-
-var (
-	_ json.Unmarshaler = (*OffsetMillis)(nil)
-	_ json.Marshaler   = (*OffsetMillis)(nil)
-)
-
-func (om *OffsetMillis) UnmarshalJSON(b []byte) error {
-	var ms uint64
-	if err := json.Unmarshal(b, &ms); err != nil {
-		return fmt.Errorf("failed to unmarshal milliseconds offset: %w", err)
-	}
-	*om = OffsetMillis{time.Duration(ms) * time.Millisecond}
-	return nil
-}
-
-func (om OffsetMillis) MarshalJSON() ([]byte, error) {
-	return json.Marshal(om.Duration.Milliseconds())
-}
-
-type TimestampedRawBlock struct {
-	// OffsetMs is the offset in milliseconds from genesis where this block is
-	// received.
-	OffsetMs OffsetMillis `json:"offset_ms"`
-
-	// Bytes is the CBOR-encoded types.BlockMsg, the same type that gets
-	// sent in the network over pubsub. types.BlockMsg contains the block header
-	// and the message CIDs.
-	Bytes Base64EncodedBytes `json:"bytes"`
-}
-
-// BlockSeq enumerates the blocks to be applied, and provides a message
-// repository that contains the message payloads.
-type BlockSeq struct {
-	// Blocks is the sequence of timestamped blocks that this vector applies.
-	Blocks []TimestampedRawBlock `json:"blocks"`
-	// MessageRepo is the repository of messages mapping CIDs to message
-	// payloads.
-	MessageRepo map[cid.Cid]Base64EncodedBytes `json:"message_repo"`
-}
-
 // TestVector is a single test case
 type TestVector struct {
 	Class    `json:"class"`
@@ -208,7 +154,6 @@ type TestVector struct {
 
 	ApplyMessages []Message `json:"apply_messages,omitempty"`
 	ApplyTipsets  []Tipset  `json:"apply_tipsets,omitempty"`
-	ApplyBlockseq *BlockSeq `json:"apply_blockseq,omitempty"`
 
 	Post        *Postconditions `json:"postconditions"`
 	Diagnostics *Diagnostics    `json:"diagnostics,omitempty"`
@@ -219,6 +164,8 @@ type Message struct {
 	// Epoch must be interpreted by the driver as an abi.ChainEpoch in Lotus, or
 	// equivalent type in other implementations.
 	Epoch *int64 `json:"epoch,omitempty"`
+	// BaseFee is an optional base fee to
+	BaseFee *big.Int `json:"basefee,omitempty"`
 }
 
 type Tipset struct {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -164,8 +164,6 @@ type Message struct {
 	// Epoch must be interpreted by the driver as an abi.ChainEpoch in Lotus, or
 	// equivalent type in other implementations.
 	Epoch *int64 `json:"epoch,omitempty"`
-	// BaseFee is an optional base fee to
-	BaseFee *big.Int `json:"basefee,omitempty"`
 }
 
 type Tipset struct {


### PR DESCRIPTION
There was a `TODO` in the driver that we should make this parametrisable. Now it is.
Also removed some blockseq types that accidentally seeped in.