### PR TITLE
Tool for applying test vectors from Ethereum on FEVM

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -332,6 +332,25 @@
           }
         }
       }
+    },
+    "tipset_cids": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "epoch",
+                "cid"
+            ],
+            "properties": {
+                "epoch": {
+                    "type": "integer"
+                },
+                "cid": {
+                    "$ref": "#/definitions/cid"
+                }
+            }
+        }
     }
   },
   "required": [
@@ -386,6 +405,10 @@
       "description": "the gzipped, base64 CAR containing the pre- and post-condition state trees for this test vector",
       "$ref": "#/definitions/base64"
     },
+    "chain_id": {
+        "title": "the chain id of the network",
+        "type": "number"
+    },
     "randomness": {
       "title": "randomness to be replayed during the execution of the test vector",
       "$ref": "#/definitions/randomness"
@@ -395,6 +418,30 @@
     },
     "postconditions": {
       "$ref": "#/definitions/postconditions"
+    },
+    "skip_compare_gas_used": {
+        "type": "boolean"
+    },
+    "skip_compare_addresses": {
+        "type": "array",
+        "items": {
+            "type": "string"
+        }
+    },
+    "skip_compare_actor_ids": {
+        "type": "array",
+        "items": {
+            "type": "number"
+        }
+    },
+    "additional_compare_addresses": {
+        "type": "array",
+        "items": {
+            "type": "string"
+        }
+    },
+    "tipset_cids": {
+        "$ref": "#/definitions/tipset_cids"
     }
   },
   "allOf": [

--- a/schema.json
+++ b/schema.json
@@ -50,6 +50,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "_debug":{
+            "title": "any kind of debug information",
+            "type": "string"
         }
       }
     },

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -66,6 +66,7 @@ type Metadata struct {
 	Comment string           `json:"comment,omitempty"`
 	Gen     []GenerationData `json:"gen"`
 	Tags    []string         `json:"tags,omitempty"`
+	Debug   string           `json:"_debug,omitempty"`
 }
 
 // GenerationData tags the source of this test case.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -169,6 +169,11 @@ type Diagnostics struct {
 	Data   Base64EncodedBytes `json:"data"`
 }
 
+type TipsetCid struct {
+	Epoch int64   `json:"epoch"`
+	Cid   cid.Cid `json:"cid"`
+}
+
 // TestVector is a single, faceted test case. The test case can be run against
 // the multiple facets expressed in the preconditions field.
 type TestVector struct {
@@ -186,6 +191,8 @@ type TestVector struct {
 
 	Meta *Metadata `json:"_meta"`
 
+	ChainId uint64 `json:"chain_id"`
+
 	// CAR binary data to be loaded into the test environment, usually a CAR
 	// containing multiple state trees, addressed by root CID from the relevant
 	// objects.
@@ -202,6 +209,13 @@ type TestVector struct {
 
 	Post        *Postconditions `json:"postconditions"`
 	Diagnostics *Diagnostics    `json:"diagnostics,omitempty"`
+
+	SkipCompareGasUsed         bool              `json:"skip_compare_gas_used"`
+	SkipCompareAddresses       []address.Address `json:"skip_compare_addresses,omitempty"`
+	SkipCompareActorIds        []uint64          `json:"skip_compare_actor_ids,omitempty"`
+	AdditionalCompareAddresses []address.Address `json:"additional_compare_addresses,omitempty"`
+
+	TipsetCids []TipsetCid `json:"tipset_cids,omitempty"`
 }
 
 type Message struct {


### PR DESCRIPTION
Tracking issue https://github.com/filecoin-project/devgrants/issues/1202.

Extend TestVector in the following two ways:

1. Context

    - Added `chain_id` field to `TestVector` ( for the opcode `CHAINID` to read )
    - Added `tipset_cids` field to `TestVector` ( for the opcode `BLOCKHASH` to read )
    - Added `timestamp` field to `Variant` ( for the opcode `TIMESTAMP` to read )
    - Added `_debug` field to `Metadata`to provide `any`kind of debug information

2. Comparison

    - Added `skip_compare_gas_used` field to `TestVector` to allow comparisons that ignore gasUsed.
    - Added `skip_compare_addresses` field to `TestVector` to allow comparisons that ignore some addresses.
    - Added `skip_compare_actor_ids` field to `TestVector` to allow comparisons that ignore some `builtin actors`.
    - Added `additional_compare_addresses` field to `TestVector` to allow comparison of more contract addresses.