### PR TITLE
feat: drop DST and entropy from randomness vectors, return digest

### DIFF
--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-1.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-1.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67344,
-        "QwCBUA=="
+        67344
       ],
-      "ret": "iltyxCSuhKQCuC3pmi3QEV5Ryx9jVrhXSFtmnU3t/ok="
+      "ret": "Da4XyK15BKX75ruaVh41foF92n5whJwU7XXfCqlMcxc="
     },
     {
       "on": [
         "beacon",
-        6,
-        68954,
-        "QwCBUA=="
+        68954
       ],
-      "ret": "R2pCJmpRVldv7MeOQnTFf4uRBGIuOOe8rG8nn53G4Co="
+      "ret": "karc7hhBva452Ws/dfoWjBK5LUsGRiNR7Fbmrk1LTOg="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-10.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-10.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67373,
-        "QwDXFQ=="
+        67373
       ],
-      "ret": "0WwgU6+kRaXmrawbHnlUpI/86nhBpU4KjDlgok7j+nc="
+      "ret": "AiyA2rVl+NYyl19EcW4kbdmMLie+qkSWVgmKfUsTdnc="
     },
     {
       "on": [
         "beacon",
-        6,
-        68967,
-        "QwDXFQ=="
+        68967
       ],
-      "ret": "ppHw2PdMCiUkyARxuqqkiTA0nEgOlsC+iDgV+1Um49E="
+      "ret": "GYJkWY5OKitJDUVmExj5JJo/WplOJRAp22jHc+kJ/Tk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-2.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-2.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        66721,
-        "RADelwE="
+        66721
       ],
-      "ret": "Vl8IPGCwF4sanXFNbhiZvL8zTLRXrQfn0SXO4xZTlY8="
+      "ret": "LR6+lc+x17OTnxGf9SGIDC335mySXiyBpVaROoqN36M="
     },
     {
       "on": [
         "beacon",
-        6,
-        68495,
-        "RADelwE="
+        68495
       ],
-      "ret": "MXpaHYri+ajJCXxZC8Uibowi81KaTgqH5Bo3TZ280Hs="
+      "ret": "1leXH/lZSpa2kKQnHOHm4qBex38h2RE22dei9ASwqPc="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-3.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-3.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        66903,
-        "QwDJGQ=="
+        66903
       ],
-      "ret": "FNBbpNN/q3lBL72illT3lXoXkxRN+ONO3vMnXcBd3cE="
+      "ret": "rPM/24OfTDbUux+pSq5XCAvp0xY2Amogs3tsav4wqH8="
     },
     {
       "on": [
         "beacon",
-        6,
-        68943,
-        "QwDJGQ=="
+        68943
       ],
-      "ret": "dIT3u22a4mtzeuJfp2MHfqs/NfTg5rN46LIXnFUy+JE="
+      "ret": "uQtYslUNE6BspWeiZ/vlEkhKCnnocB2HjqGtd57sXSU="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-4.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-4.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67394,
-        "RACqoAE="
+        67394
       ],
-      "ret": "pn9gNh6wCQkH1MnrPq8lvEuvAX1Fxtdz1HxrdDaez9g="
+      "ret": "EY6UEQjbKsIp7JjJ4YAEF8hdDnNF1XIhGSjYN3jDLTc="
     },
     {
       "on": [
         "beacon",
-        6,
-        68830,
-        "RACqoAE="
+        68830
       ],
-      "ret": "APCeCYPDQ6zdEMyKhIeFoFrfEXqXEkK9jDPFIVaw69M="
+      "ret": "V7YjyVRJe1SzHLteGk0WFbj1G5kgQPl/svAWhhG9sjs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-5.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-5.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67302,
-        "RADfkgE="
+        67302
       ],
-      "ret": "FzNOxajoVGEkJ+myqBviTK29qTy9zeZ14cc0RBo94p0="
+      "ret": "aw6pIdcjvWTx3BkmTGkuJfN6ZOKxNCZTOulKqObebws="
     },
     {
       "on": [
         "beacon",
-        6,
-        68948,
-        "RADfkgE="
+        68948
       ],
-      "ret": "2JXm9se5wiHs35xMYa+8/OSZ4leTc9QBGTUnf/Mbh74="
+      "ret": "5Q3PjCCT2tXctRTT+1jj1WYiPgUvP1MyZRq2QznsuIA="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-6.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-6.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67391,
-        "QwDXFQ=="
+        67391
       ],
-      "ret": "YCjTwYj3bcTLTjaw3+Y1/GEV2GkZeU/UtYnxtHWWMHE="
+      "ret": "N3kqJrzuJy46mPexqkac7K28NyEjT5EzXLDzUPDRJzo="
     },
     {
       "on": [
         "beacon",
-        6,
-        68967,
-        "QwDXFQ=="
+        68967
       ],
-      "ret": "ppHw2PdMCiUkyARxuqqkiTA0nEgOlsC+iDgV+1Um49E="
+      "ret": "GYJkWY5OKitJDUVmExj5JJo/WplOJRAp22jHc+kJ/Tk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-7.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-7.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67306,
-        "QwDTCQ=="
+        67306
       ],
-      "ret": "wxgtDsSbV9VQQC+Lm8tYv2rFMSoQy1oOnjua7aI6v0M="
+      "ret": "6xctGUUAkBzoPrKOItkxDXPsRv5gor4C8avIem0LBKI="
     },
     {
       "on": [
         "beacon",
-        6,
-        68941,
-        "QwDTCQ=="
+        68941
       ],
-      "ret": "tPnyqIbyP9dUs+v5vtWmdfwktmywe4jxHjgsl0rlowI="
+      "ret": "0Iw0SvhKTlZycwuQUcfxGjxARYNjELgm2Au9CvVTIIY="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-8.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-8.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67315,
-        "QwDXFQ=="
+        67315
       ],
-      "ret": "XQWMB+SH+q+8U4tUkmXWkVoW/lFBBF13rc3+K3FxBxE="
+      "ret": "H5/4FT/y1H08EHi8ySmA51Fi+2sk1PZVOh7HuJA/yUA="
     },
     {
       "on": [
         "beacon",
-        6,
-        68967,
-        "QwDXFQ=="
+        68967
       ],
-      "ret": "ppHw2PdMCiUkyARxuqqkiTA0nEgOlsC+iDgV+1Um49E="
+      "ret": "GYJkWY5OKitJDUVmExj5JJo/WplOJRAp22jHc+kJ/Tk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-9.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/Ok/ext-0001-fil_1_storageminer-ProveCommitSector-Ok-9.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67294,
-        "QwDTCQ=="
+        67294
       ],
-      "ret": "4zgxqlZQ5TghStK4kLH7Jh2ouMM5BuHQjpLpx9QZ/zk="
+      "ret": "ByfDQn0ozUua/MNfZXEzHq/X+6IE5ANtbmhfkDEo9/c="
     },
     {
       "on": [
         "beacon",
-        6,
-        68941,
-        "QwDTCQ=="
+        68941
       ],
-      "ret": "tPnyqIbyP9dUs+v5vtWmdfwktmywe4jxHjgsl0rlowI="
+      "ret": "0Iw0SvhKTlZycwuQUcfxGjxARYNjELgm2Au9CvVTIIY="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-1.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-1.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67308,
-        "QwDXFQ=="
+        67308
       ],
-      "ret": "AQytHn40KVGwZn15RN7NUaPCreel2k/iY9Q1J4GdISg="
+      "ret": "oZHzdKmEiTcK4zW8BFqVW/i1CMTZG1x+9ENjxo7aNQ8="
     },
     {
       "on": [
         "beacon",
-        6,
-        68967,
-        "QwDXFQ=="
+        68967
       ],
-      "ret": "ppHw2PdMCiUkyARxuqqkiTA0nEgOlsC+iDgV+1Um49E="
+      "ret": "GYJkWY5OKitJDUVmExj5JJo/WplOJRAp22jHc+kJ/Tk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-10.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-10.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67252,
-        "QwDXFQ=="
+        67252
       ],
-      "ret": "yY/7C1AkBLtJI8NJTSUeO9xpnnHcxblelw8DOLrADPg="
+      "ret": "OfTavicqPFv11Z4Z9JjW80aamHAULVtsb1mA1hM/tls="
     },
     {
       "on": [
         "beacon",
-        6,
-        68961,
-        "QwDXFQ=="
+        68961
       ],
-      "ret": "F2KJAS1PJLfG7XymXgX7V/79oaKhU6IUaqBXU5v5X+U="
+      "ret": "duMFfOGJp7DT2kkXCMGB5o42mIuBzyi7sDhlaZkZSjs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-2.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-2.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67244,
-        "QwDXFQ=="
+        67244
       ],
-      "ret": "ka+LwiW2545xmvAnyWEst06TdBgYee+6eDC5A97f4FE="
+      "ret": "N+cXPzq7EPp2usJ2lvtlvnAdpQNDtOJxbv0gVxscQUk="
     },
     {
       "on": [
         "beacon",
-        6,
-        68961,
-        "QwDXFQ=="
+        68961
       ],
-      "ret": "F2KJAS1PJLfG7XymXgX7V/79oaKhU6IUaqBXU5v5X+U="
+      "ret": "duMFfOGJp7DT2kkXCMGB5o42mIuBzyi7sDhlaZkZSjs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-3.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-3.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67261,
-        "QwDXFQ=="
+        67261
       ],
-      "ret": "7ySWGaE6FHBLn5UvanaVoFqyVBJY1xDxxCQScVktlMg="
+      "ret": "RRva12CVVPfNdpXuFkuIgjoZEjvmhvULQS+VaVZ7hiE="
     },
     {
       "on": [
         "beacon",
-        6,
-        68961,
-        "QwDXFQ=="
+        68961
       ],
-      "ret": "F2KJAS1PJLfG7XymXgX7V/79oaKhU6IUaqBXU5v5X+U="
+      "ret": "duMFfOGJp7DT2kkXCMGB5o42mIuBzyi7sDhlaZkZSjs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-4.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-4.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67339,
-        "QwDXFQ=="
+        67339
       ],
-      "ret": "vVpDxvk9wxLOVTukZm5N8yRbl17sDVsTSYFO/lXQ2Xw="
+      "ret": "CsWcFuRtkvCpBGVvP/+RFcpmQwXBeguzaRfZqNX+BNk="
     },
     {
       "on": [
         "beacon",
-        6,
-        68965,
-        "QwDXFQ=="
+        68965
       ],
-      "ret": "eCa4+mU48yPfQypFtndU4TKiMwPQfaozMOSpQEpRVEM="
+      "ret": "YqQvjuoHmJJYNuTpZLYLtQ7YCxHcwJV2ZZiOeQ0ORHY="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-5.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-5.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67331,
-        "QwDXFQ=="
+        67331
       ],
-      "ret": "XsPgiNAnDLTM6rdVAbUseSA52JwlJKAQAb0WK1Bt+Cw="
+      "ret": "Jt4pgjPC/mbt977668/LDZCfANG6n2tIWJxreKXy/IA="
     },
     {
       "on": [
         "beacon",
-        6,
-        68961,
-        "QwDXFQ=="
+        68961
       ],
-      "ret": "F2KJAS1PJLfG7XymXgX7V/79oaKhU6IUaqBXU5v5X+U="
+      "ret": "duMFfOGJp7DT2kkXCMGB5o42mIuBzyi7sDhlaZkZSjs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-6.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-6.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67239,
-        "QwDXFQ=="
+        67239
       ],
-      "ret": "PM6S8gjoQia246y09noLfBWCuK41Y13ybzsYgwDrhW8="
+      "ret": "DSfyg0fd/TVdRYZggmuM+M32kBk7czR7Q2H9+kcwPH4="
     },
     {
       "on": [
         "beacon",
-        6,
-        68961,
-        "QwDXFQ=="
+        68961
       ],
-      "ret": "F2KJAS1PJLfG7XymXgX7V/79oaKhU6IUaqBXU5v5X+U="
+      "ret": "duMFfOGJp7DT2kkXCMGB5o42mIuBzyi7sDhlaZkZSjs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-7.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-7.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67244,
-        "QwDXFQ=="
+        67244
       ],
-      "ret": "ka+LwiW2545xmvAnyWEst06TdBgYee+6eDC5A97f4FE="
+      "ret": "N+cXPzq7EPp2usJ2lvtlvnAdpQNDtOJxbv0gVxscQUk="
     },
     {
       "on": [
         "beacon",
-        6,
-        68963,
-        "QwDXFQ=="
+        68963
       ],
-      "ret": "Raom/qWZzGTWgMDz7VM5aDj2DAT/nbzMgG6nr7Jrm78="
+      "ret": "ZviyDGAX1qqdRv93yb4l/Ji6Qw7rqmWdeq0wt8er960="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-8.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-8.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67294,
-        "QwDXFQ=="
+        67294
       ],
-      "ret": "MRVwDb/nlp1WBsMmQKsTuK37Wp5RtI0uzEf3tTkco6A="
+      "ret": "ByfDQn0ozUua/MNfZXEzHq/X+6IE5ANtbmhfkDEo9/c="
     },
     {
       "on": [
         "beacon",
-        6,
-        68961,
-        "QwDXFQ=="
+        68961
       ],
-      "ret": "F2KJAS1PJLfG7XymXgX7V/79oaKhU6IUaqBXU5v5X+U="
+      "ret": "duMFfOGJp7DT2kkXCMGB5o42mIuBzyi7sDhlaZkZSjs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-9.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0001-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-9.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        67241,
-        "QwDXFQ=="
+        67241
       ],
-      "ret": "/yek+Rk/scMDNUt8TkdvwGgdNyzPWi8rWwu0UxjZinQ="
+      "ret": "7xL17jpFYdJrbc8uNzjsEwQ9INxPGtqfpI+w0jBCLw4="
     },
     {
       "on": [
         "beacon",
-        6,
-        68953,
-        "QwDXFQ=="
+        68953
       ],
-      "ret": "zwmJTs30hz1Dz9u6USdOVFUmj4MxkhSDWWJoCqr01wo="
+      "ret": "MR8r1h/bHLhjOqWIOZoKKafMfzm2ytQxEvAiZNNkIPM="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-3.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-3.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        67399,
-        ""
+        67399
       ],
-      "ret": "iRNDZHXW7S90TMKnmYgOZ6NY42zGGEcvYda4JaIZ5rw="
+      "ret": "W44RGDAkqJHNVxkTmLm8owwd6O/pHfUZs2+ATXjujyU="
     },
     {
       "on": [
         "beacon",
-        4,
-        67379,
-        "QwDTCQ=="
+        67379
       ],
-      "ret": "AmsN/xae6e9v0iZAglsvh0j12m3F4oOlhUSFflSfBiY="
+      "ret": "wdBg/KQ4S0gpr3lxk0ekYR/cAV7W00NQe6xDpRhZU+4="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-4.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-4.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        67283,
-        ""
+        67283
       ],
-      "ret": "C+YCCu4S69DRPEaHciPgvAAxnFRdq1TGjwejKNWxk6w="
+      "ret": "mJ621WFn0YjH8sBaKBR3qxXKvIV7zdH3uUB+xLMEDPg="
     },
     {
       "on": [
         "beacon",
-        4,
-        67263,
-        "QwDNRg=="
+        67263
       ],
-      "ret": "RMGs+DEhw/h89vDvbas7VCjWkkQqD3giJ6est7Qhjw4="
+      "ret": "udTpXwwG79R1nS5hZjS50wuKD0hwWBtbe2SpBQ0LzmQ="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-5.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-5.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        67279,
-        ""
+        67279
       ],
-      "ret": "AO9b+pYnbGmmGjrNO4V/VSbkWkdjaIW/RIymlcgjYGk="
+      "ret": "h0Ryc+AJ73dDR+iqhD/pvWSaFE17XirahYHPfgSpXVM="
     },
     {
       "on": [
         "beacon",
-        4,
-        67259,
-        "QwDTCQ=="
+        67259
       ],
-      "ret": "RtFcl3QHiwNQFSlA1dvikqLVWs/KybqnadNobXpdDDQ="
+      "ret": "+PNo4aZBve/kXgPpWtPYfM/927Xy3OavDup5GKNCywU="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-7.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-7.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        67163,
-        ""
+        67163
       ],
-      "ret": "Cn9eKBaU1O8rNoJDqV0BFKnopq95ovLJkApBg2HUdZA="
+      "ret": "CTqHZRod8FinqEOwzVcnoHap9M/UGm0fHuFOjkOVg1Y="
     },
     {
       "on": [
         "beacon",
-        4,
-        67143,
-        "QwDNRg=="
+        67143
       ],
-      "ret": "sR2y8e7rePB0+JWCY/7eM6fYe4T5qTG87vNzinXQ2gg="
+      "ret": "NZt7yZw8k55PLVuzn4M38RWBKjfpucsSZsJh+z/kdP4="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-8.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-8.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        66923,
-        ""
+        66923
       ],
-      "ret": "2opqo1fYb/Ip3B15KOkFD+UbEW5eAQO2Ra1akFXSr5U="
+      "ret": "P9GQXaMYzq9c6FJfwBVK07kESqa26K7YW7cgu9piHsw="
     },
     {
       "on": [
         "beacon",
-        4,
-        66903,
-        "QwDNRg=="
+        66903
       ],
-      "ret": "Tk61+1o0qjwsbQ0MigoGo7p8x+riYJDA5nR2KB99cTE="
+      "ret": "lQ8TdHL/d3q+6fcSd3xm7czs4FWHwI5a4PKAqz0uGVA="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-9.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/16/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-16-9.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        66919,
-        ""
+        66919
       ],
-      "ret": "jvBx7AOLHv2OR6oV4B6HyxFsv30f8/kFW7XxAgPTWKs="
+      "ret": "DoZ77/0cvUoM71fk9t+dH9pNYVG6QuH9VJ30GWVDBEU="
     },
     {
       "on": [
         "beacon",
-        4,
-        66899,
-        "QwDTCQ=="
+        66899
       ],
-      "ret": "rOK+PYDUfp2o7WL09NiKldty7fhcF5iyjxITMNdkyis="
+      "ret": "ZvCSaF99LKtWAYHKFpi0p42s3vEIocsJrh2vFWSvPmo="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-1.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-1.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        68972,
-        ""
+        68972
       ],
-      "ret": "4iCP//q2JOqVsVfHwMS95EQq4itsevnVLZLTzDh0nEQ="
+      "ret": "BwIwdcW1d0j5hE4N0ca2mrukvDD5n4ta1YzaKljADzo="
     },
     {
       "on": [
         "beacon",
-        4,
-        68952,
-        "QwDrcg=="
+        68952
       ],
-      "ret": "AkTAYg1dJfNm4QDnuLwukZziRqn1ROfWsu1fZ7q9sQE="
+      "ret": "Wj9nQt2HdZedntLeSZUoqYdKmx6euAWtWLg2agGv7yk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-10.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-10.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        68976,
-        ""
+        68976
       ],
-      "ret": "+gbAkghHZkKAze71SGCxch1IG9JrFONLZMdZn5UEpJg="
+      "ret": "2KUQgOwI+Hcz4I70h4guEsKwr6rxe/GF3xr1BgElwdM="
     },
     {
       "on": [
         "beacon",
-        4,
-        68956,
-        "QwDZCQ=="
+        68956
       ],
-      "ret": "BDnS6zYS4o8m5gfXRsMWU2/gmsx2fJMAog56iJ165Rk="
+      "ret": "evKhYxDQxk9QPGfyIkzf2qt6IDV6XzFwNn42ug9sGmw="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-2.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-2.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        68940,
-        ""
+        68940
       ],
-      "ret": "asO1FHEYsBf6kPWUbJ5WHTXaJuYdp/UId5xfdN3xlk4="
+      "ret": "Eut0YBBva4UovLu1NK0O+I7iaWepKiJwJqKprGpMAxw="
     },
     {
       "on": [
         "beacon",
-        4,
-        68920,
-        "QwCcfA=="
+        68920
       ],
-      "ret": "XzTCzZii69xzpTopbgtMWn5K62ru8gjOdZDThY1fGik="
+      "ret": "SpKk7MPkPix461DYOz0BYcYlPEPi9iciKJaoh6rDSWo="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-3.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-3.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        68943,
-        ""
+        68943
       ],
-      "ret": "fxyZ34Ok2+xpojaHxl0++ytVbFaeColMQ7FouS6JLUU="
+      "ret": "e7La7rSIuBNGI59a5dN5Q6xWt/9rfJVUZAptD283zQ4="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-4.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-4.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        68975,
-        ""
+        68975
       ],
-      "ret": "qmibYgDkpuVqvwvnIJHI3QKRn66bzzsHhhgs0noahsE="
+      "ret": "DjVu/bKbZazB7drQ5wQhPk+n7hWBG1p4BjmWNTQVwLs="
     },
     {
       "on": [
         "beacon",
-        4,
-        68955,
-        "QwDCFA=="
+        68955
       ],
-      "ret": "NH/yY8KM+Z2/q2H7QhSVReyeA5BQCl7ri8FIONfoFAc="
+      "ret": "HIlPMm6lDev7A8jA3aeKrcDKmMEb3Z5Y1kbJGwHjVcU="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-5.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-5.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        68959,
-        ""
+        68959
       ],
-      "ret": "+RIPjyDrgYPRgS6tcOZvfY7WAutFda9Cymwy3VboOkI="
+      "ret": "JQ2TJSZ7YmQ4fyKuvak+elPOpr/TFsQvzmhYdhC3A9w="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-6.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-6.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        68977,
-        ""
+        68977
       ],
-      "ret": "K0V+6hbzjb3Swi0fBHRUhEQWxp9Xlf4cIPLH4236Iqs="
+      "ret": "EJqolg9gDl9bSFP9gevQtVc7TdPEPbDwodv3hLTq3tc="
     },
     {
       "on": [
         "beacon",
-        4,
-        68957,
-        "QwDDKQ=="
+        68957
       ],
-      "ret": "BnRP/4kKJ2IhgqPbIcqjlqnoCapdXkFdPxNHjyj5iw0="
+      "ret": "j6u7nrdKgumhBMzc/rT0xHKAJy9PfUo+EJBEB2bypFY="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-7.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-7.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        68970,
-        ""
+        68970
       ],
-      "ret": "X6iHwg7JJ7RNT5iQExBZkbzGAkNfSyKPc3CknEh1umE="
+      "ret": "p+JhV9S10X0zKKwfel3MDqzj/ifR1DRSLdkbh3YMkXY="
     },
     {
       "on": [
         "beacon",
-        4,
-        68950,
-        "QwD0Eg=="
+        68950
       ],
-      "ret": "Z+yaBmchmj2jzxhpVUU1T4w/eEcKITTo11bhHkVR+C8="
+      "ret": "JtwSJD3amw/0GJ/rfn3HrhApCth/A5/tUxwp9uUfyfg="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-8.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-8.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        68973,
-        ""
+        68973
       ],
-      "ret": "1uA2V7e0BVEKkmgubVukxcHo4nxWn/qwOvjNsdZ7YdE="
+      "ret": "D6Q6NAdFBe/CE24GL63ty+30+R7FgoSglJx+6+k/0ZQ="
     },
     {
       "on": [
         "beacon",
-        4,
-        68953,
-        "QwDLGQ=="
+        68953
       ],
-      "ret": "2qD5z/c1lMu00i8mE10dSIff4MF4ImRC9vucAbeWIQ0="
+      "ret": "MR8r1h/bHLhjOqWIOZoKKafMfzm2ytQxEvAiZNNkIPM="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-9.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-Ok-9.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        68953,
-        ""
+        68953
       ],
-      "ret": "MI4cwQz8mQmrgmm8+ctsLVGZ++5kWpBuIpC2JP5kcYE="
+      "ret": "G0JANK6BdYMusAtsiqs0hcnVbDPBAxpM9TWPDJ00WLs="
     },
     {
       "on": [
         "beacon",
-        4,
-        68933,
-        "QwD2Eg=="
+        68933
       ],
-      "ret": "phhMWGOP+0yHMUeOWoW1T0rD7ISuMOwhD/0zwCTbwis="
+      "ret": "pN9UusvVLB7afJbLrDi1u8vaKnpRI/YBh8ROmr+/gqs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-1.json
+++ b/corpus/extracted/0001-initial-extraction/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0001-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-1.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        64984,
-        ""
+        64984
       ],
-      "ret": "3OM3fc1xvzpecu8GDD/FZ8hup9ugTU2q6c2cadj0xvw="
+      "ret": "CT4lKk5s4jCCtk8ch3f9tnjUSw/iivz8CpRsAHreA5U="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-1.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-1.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        54558,
-        "i9gqWCgAAYHiA5IgIGK+WSkOwQD4jdzdcvByTFX9rjTMgRUxRGv5Sc9LXCc8GgACAAD0QgBwQwCFUngzoWVwY2lkc4HYKlgnAAFVoOQCIJl6labV+zHTlOXdUFvmaf5915ylHpW73ZgB7Xi5JC9XGepiGgALo29DAO5rQEA="
+        54558
       ],
-      "ret": "hmJSG4mKuAHbueAior6lPC150fDBAqG5ODqg6Fs3+AA="
+      "ret": "aBRrtb9sa8Eel7IZ+tf7kG/86hrV3jYluPWpAt33iT8="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-10.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-10.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        48371,
-        "i9gqWCgAAYHiA5IgIHqdzheWtSBN+T+N/Cr1UJVyJm1OcGvoTArqaG3NSm0GGgACAAD0QgBwQwCbUngzoWVwY2lkc4HYKlgnAAFVoOQCICbCkHu2is9Z1Gv07YekH16Hso+VoopBDs3lRtTjrUM2GdBqGgALjTxDAO5rQEA="
+        48371
       ],
-      "ret": "64aADoPzfTn49Qh9y5kbdgpYX361/if8vekSnuk8Om0="
+      "ret": "5a04HbIDasoTyIbFXWXMu1jyOt/vql7NAxj4M3pszo8="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-2.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-2.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        54119,
-        "i9gqWCgAAYHiA5IgIIWyZA2d2Nv8x26hZ+xpIlMdEGWhiyAwuTcNWxfPmkM4GgACAAD0QgBwQwCFUngzoWVwY2lkc4HYKlgnAAFVoOQCIEt09wSFMdPVEo1S5uNjD41dCZGl2sIbDU7YIMv377BbGehIGgALo29DAO5rQEA="
+        54119
       ],
-      "ret": "ceg1HqNkH3CKZ8ksiecK3+c/qDQPtRqBc7XwCpgia2o="
+      "ret": "/A6CZ8yC2n7zcOVFsd62seb1SA7mAypeqMQq7m5te7U="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-3.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-3.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        54035,
-        "i9gqWCgAAYHiA5IgIANhg96IxwfzSzXwZtmrDTsqozVBCtQjlVkH+cVvVewSGgACAAD0QgBwQwD2EngzoWVwY2lkc4HYKlgnAAFVoOQCIDYqeMhEPI9vG2yNR5lfYlfwXRLqlSvZvrCHIXF+CvnMGejZGgALpFxDAO5rQEA="
+        54035
       ],
-      "ret": "waBtAHblxlyBSn8uVY9w0H8hJJ9m4TR41RwQ1E/r0e8="
+      "ret": "jqcv8ROh0F3ZBn8oidHGiM1fpoFovSf+l4jnsw5RB7E="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-4.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-4.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        48552,
-        "i9gqWCgAAYHiA5IgINL7JchqDZUaTct683fxITm8ObwOnjcXEpf9F8fX3kAyGgACAAD0QgBwQwCFUngzoWVwY2lkc4HYKlgnAAFVoOQCIHAVhiDk/Fd74G4JUdQ0Tpl8D3l117jnz+rXotx1TzS6GdD6GgALjO9DAO5rQEA="
+        48552
       ],
-      "ret": "ns7nmC8Jsa5pI3FBYCUCHBY/vOMlEG0/1Ijz8r52o+U="
+      "ret": "5mI0j9YCziaKK5VaGuCPSs4La7v7OuNWo6v320FgMiI="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-5.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-5.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        48552,
-        "i9gqWCgAAYHiA5IgIBfPTmkn/JzzBl/6fp1g0VJZF3oDILA0pDxGu1KmRQIqGgACAAD0QgBwQwCFUngzoWVwY2lkc4HYKlgnAAFVoOQCIFxTzhjY5M7tZ6pjKB3F15Q5A1N4zZsotZtOI7TQsE3JGc/rGgALjO9DAO5rQEA="
+        48552
       ],
-      "ret": "hH1khKcyEWlUbTRNwT32BygcENUce0JHHuyN7CfsUMU="
+      "ret": "5mI0j9YCziaKK5VaGuCPSs4La7v7OuNWo6v320FgMiI="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-6.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-6.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        48552,
-        "i9gqWCgAAYHiA5IgIDqvcdzrItZIC/4hqsZM4CJWxLuacwvAOr1g1NFj9vUbGgACAAD0QgBwQwCFUngzoWVwY2lkc4HYKlgnAAFVoOQCIIMOs4Hijrmvm1zDew9Uo3O2qig1VcdXyVJPtFugx8OFGdBvGgALjO9DAO5rQEA="
+        48552
       ],
-      "ret": "4QyqAgt/W4yFH7OWpHS8+aZ8C/ut/h3z86/39W71gOI="
+      "ret": "5mI0j9YCziaKK5VaGuCPSs4La7v7OuNWo6v320FgMiI="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-7.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-7.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        48371,
-        "i9gqWCgAAYHiA5IgIM2T89sQs481vtpjtTkRm2+Ewy7zBG3co+95KNGQdzYHGgACAAD0QgBwQwCbUngzoWVwY2lkc4HYKlgnAAFVoOQCIIHsNRg+eE867JKZgr6Z/Lm5yBamSFFAd/874a/4oShjGc9iGgALjTxDAO5rQEA="
+        48371
       ],
-      "ret": "MbhBYI1kO/s3s1il9hv4y82Vy01NnFvt/sdtDHh1nB0="
+      "ret": "5a04HbIDasoTyIbFXWXMu1jyOt/vql7NAxj4M3pszo8="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-8.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-8.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        48371,
-        "i9gqWCgAAYHiA5IgIBEjJj66d4BDHNbjrHlddc5FB6pOf22p/rJOVFhf0IUYGgACAAD0QgBwRADwhQF4M6FlcGNpZHOB2CpYJwABVaDkAiCPy5kQ78BqNb+irlncqnbwEz1OoNarpt6/Lw2eFxan0RnRDxoAC418QwDua0BA"
+        48371
       ],
-      "ret": "PCfy0zFHHvAJj2qwXJcCYRFmN0UrdrUPdWqIz3sA2lM="
+      "ret": "5a04HbIDasoTyIbFXWXMu1jyOt/vql7NAxj4M3pszo8="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-9.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storagemarket/PublishStorageDeals/SysErrOutOfGas/ext-0004-fil_1_storagemarket-PublishStorageDeals-SysErrOutOfGas-9.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "beacon",
-        8,
-        48371,
-        "i9gqWCgAAYHiA5IgIGnjo7QJp/KfcSVsn7Q0eLS2gv/EpJDdMXA2/cHRZ/w6GgACAAD0QgBwQwCFUngzoWVwY2lkc4HYKlgnAAFVoOQCIMcV42EPIvWgGxWbRo9EMcowKLcEg1ss0Jq3gkmfXOTJGc4pGgALjO9DAO5rQEA="
+        48371
       ],
-      "ret": "aMEAmCCv1nv8+w2p9aU/Qr8fSSSyrS7oWB9IrNE3cU0="
+      "ret": "5a04HbIDasoTyIbFXWXMu1jyOt/vql7NAxj4M3pszo8="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-1.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-1.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55763,
-        "QwDNRg=="
+        55763
       ],
-      "ret": "mSMs8EqPiQrkCk3DL0Av3zY39o84ASAfSeoWXWwoVKs="
+      "ret": "FGtMyOk2vNIPo+/xxcTHuLL+WW0XAXzXhGzeQSeKkec="
     },
     {
       "on": [
         "beacon",
-        6,
-        57510,
-        "QwDNRg=="
+        57510
       ],
-      "ret": "Rm1GrJxKIjfgdrvfeA9Vq0olDSlgEhCpFIaGLiPh4Jw="
+      "ret": "9MFuUChYyHQrbjOdWhTXgknpRwBJrqjcTmbLsGMqYrc="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-10.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-10.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        54923,
-        "QwDXFQ=="
+        54923
       ],
-      "ret": "tHFk1CfrCz+f4qmpWj52+to+lDZ7fU23Jmts1bJGKw4="
+      "ret": "iVdzxeN++LEEn03vhoRX2+vlbHQ2EIb7Vt3J+9SHDiA="
     },
     {
       "on": [
         "beacon",
-        6,
-        56518,
-        "QwDXFQ=="
+        56518
       ],
-      "ret": "izsNEI/1JKTPtmWT7eVey982nakGo9fFLP6U7a9IgiY="
+      "ret": "s1K9DNoggOxJmXYrsxEE4DbQFxWFReF/3U9TqqWPfDE="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-2.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-2.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55759,
-        "QwDfEg=="
+        55759
       ],
-      "ret": "jAtHVsqQDSXUU3RsDigIUxvioXukySWmL3ziPu5GOZk="
+      "ret": "HWbp9ytjofmtV+DjIYVACggZBGlhbQukNSpY65sGJnw="
     },
     {
       "on": [
         "beacon",
-        6,
-        57450,
-        "QwDfEg=="
+        57450
       ],
-      "ret": "29wSm7ZeJMycU9csmO87XKzLxRyo0hHlWul/Zw6sij4="
+      "ret": "0eh86Aa5Ab4lDnu+vYoxfofklw8xHqcuzbAFLgei1+U="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-3.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-3.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55703,
-        "QwDgCQ=="
+        55703
       ],
-      "ret": "W3KyZ+JVZ6uIExbu5OD9ZIk047ZRHWSoHzF8uRG/A5I="
+      "ret": "+4Vogi/cR12reBgsEq9bFPnti4NtV+TWEqnlP0yOjTU="
     },
     {
       "on": [
         "beacon",
-        6,
-        57515,
-        "QwDgCQ=="
+        57515
       ],
-      "ret": "5TTuFQz31otpCf7E4OzVO+EmeJEYH4cuY0XEuZfdrE0="
+      "ret": "sbdEGufK+cFDbNWqV6jmUu9O+HCUG9+HuHfM53IceiY="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-4.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-4.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55296,
-        "QwC2FA=="
+        55296
       ],
-      "ret": "Q/UZp/jvTqlhQIhw/U0FY4737z6oGv/8m2vgO7GWILM="
+      "ret": "EkznPqvK8QgioUdLx3+L2UdiFQ7VkNgjTqe/MB4PQ8s="
     },
     {
       "on": [
         "beacon",
-        6,
-        57318,
-        "QwC2FA=="
+        57318
       ],
-      "ret": "p6fX3lj457WVysaoCVSv6PmOQk7sV4pvmfevTIADK9o="
+      "ret": "8rQxijubzRobDbSBH0Qbvnxp1LE7kqJRO80i5ppmpoU="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-5.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-5.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55734,
-        "QwDoew=="
+        55734
       ],
-      "ret": "0xgKx0jZE8VbBEhmXe+IcF8Ey5fzFE//WTeJ7K86FNQ="
+      "ret": "DHnaPygWIacyAEtf2FNV6hGnFZfYdhPsfEKYa2MH3bo="
     },
     {
       "on": [
         "beacon",
-        6,
-        57463,
-        "QwDoew=="
+        57463
       ],
-      "ret": "A1xmyUZ9fFlKqceaGH//V9e2sIxhsf5JGArXHAZCBqY="
+      "ret": "DAieWHcuSjlQLnX4Pv2cL+PF8lbwk9DXoj9ePyhII7s="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-6.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-6.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55932,
-        "QwDgCQ=="
+        55932
       ],
-      "ret": "En/R3dE+ob9lhlTN5UyqPrFh9F6Nfzls67eF6O0FSmA="
+      "ret": "jK0iiF9r58kXrDfrYF3JG5A5YHwY86z/ofg3EaP9kJk="
     },
     {
       "on": [
         "beacon",
-        6,
-        57495,
-        "QwDgCQ=="
+        57495
       ],
-      "ret": "v+8BrEyhogMtI67OP0UQb6hgh4Xq223uxAy2c9ZP2xo="
+      "ret": "r/wvCOXi9FhZMAI4K99OgZeiptIX6Cerm0nl/i8CdZQ="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-7.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-7.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        56060,
-        "QwDgCQ=="
+        56060
       ],
-      "ret": "cTutWgtWc1qcdM576wxgDeGVgvd2u+mEDesjBf8ubqA="
+      "ret": "Wlatd+RhO8JO9KKB9xXIl3Pke+XWvoeoiDuxBArraWg="
     },
     {
       "on": [
         "beacon",
-        6,
-        57515,
-        "QwDgCQ=="
+        57515
       ],
-      "ret": "5TTuFQz31otpCf7E4OzVO+EmeJEYH4cuY0XEuZfdrE0="
+      "ret": "sbdEGufK+cFDbNWqV6jmUu9O+HCUG9+HuHfM53IceiY="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-8.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-8.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55649,
-        "QwDoGA=="
+        55649
       ],
-      "ret": "8vE2+mm03OrxBk3Oy3zNEWK6C9TnnzGxkv4N2NqplpM="
+      "ret": "ngKjdBMBi60N47T7SI5stk26vxReWCckTlgsouXTCDM="
     },
     {
       "on": [
         "beacon",
-        6,
-        57175,
-        "QwDoGA=="
+        57175
       ],
-      "ret": "UWsvpEgcwno/2zOEeQHc6Ymvk2Xh6d29RupTBEcsh64="
+      "ret": "wC8+OBqInKdyWdW+8z6dFK7/XYCv1d3QMIS9lqRu0w4="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-9.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/Ok/ext-0004-fil_1_storageminer-ProveCommitSector-Ok-9.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        56115,
-        "QwCGEw=="
+        56115
       ],
-      "ret": "HsLZ16rsBTqnIANcGLTdJmy3tpO6qdsVJdnfj21+mpo="
+      "ret": "FvhUJyrx4elr+97O0T5SM/UJAAfzOFGvgjUV/Lkso+g="
     },
     {
       "on": [
         "beacon",
-        6,
-        57500,
-        "QwCGEw=="
+        57500
       ],
-      "ret": "retasxRQW+Za2g5DidP3b5fdE1T7mHLU7HDWTmsbuBs="
+      "ret": "9TPTNMKn5Nk/57BcCEu29zSirmZ9zET1T9SNFWjjVbQ="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-1.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-1.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        56074,
-        "QwDgCQ=="
+        56074
       ],
-      "ret": "tnJEqsktu0silZMdxWoiAC3BoQqiyD2blJf8OOycEVI="
+      "ret": "IawGY7G/n36l8ZXGdu9ZfiPR4+f/z3qlOH42rsaSy6w="
     },
     {
       "on": [
         "beacon",
-        6,
-        57508,
-        "QwDgCQ=="
+        57508
       ],
-      "ret": "ErUszNPi1z9BRRqbWMqHfoRlMcWTyu8TzhX4GzwhZrw="
+      "ret": "GVI49o2dlmssm4HOMQnZPcHxxL0IXNJ2xy6BNMdbNfk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-10.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-10.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55857,
-        "QwDPFQ=="
+        55857
       ],
-      "ret": "PpyUC9PoNCrtmPZyqIh7kIMKg2qJU4UE5fhjre2ab08="
+      "ret": "WJSLK7wT33yz2oZiWUlrorDAciDQy6GWe1JCBpNRnmE="
     },
     {
       "on": [
         "beacon",
-        6,
-        57518,
-        "QwDPFQ=="
+        57518
       ],
-      "ret": "vD7aV6I67wvaas6s8iSuYtVdpOg5fCs7WKrjMt1ByIo="
+      "ret": "8vvrOPRQwc1Ne0xfOwyV8W8DKDvFr+qZChGVS2fFXrQ="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-2.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-2.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55987,
-        "QwDgCQ=="
+        55987
       ],
-      "ret": "F0Fy/K1YD8rANIlFlIdq2xzbdjH8UMfT8i895QXcUBM="
+      "ret": "w9+fWDCqs37qmtX7zaKqp1C0md599eN5cbD53abPbl0="
     },
     {
       "on": [
         "beacon",
-        6,
-        57508,
-        "QwDgCQ=="
+        57508
       ],
-      "ret": "ErUszNPi1z9BRRqbWMqHfoRlMcWTyu8TzhX4GzwhZrw="
+      "ret": "GVI49o2dlmssm4HOMQnZPcHxxL0IXNJ2xy6BNMdbNfk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-3.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-3.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55826,
-        "QwDfEg=="
+        55826
       ],
-      "ret": "/WDqAxLXwZBQPaVzvvPKVVszAZBlelW8LcMYaiAsS5c="
+      "ret": "IfK0tfs4U8n4MoiAS3v/6q7IOHIJLyX/oT9O1ymhnSY="
     },
     {
       "on": [
         "beacon",
-        6,
-        57450,
-        "QwDfEg=="
+        57450
       ],
-      "ret": "29wSm7ZeJMycU9csmO87XKzLxRyo0hHlWul/Zw6sij4="
+      "ret": "0eh86Aa5Ab4lDnu+vYoxfofklw8xHqcuzbAFLgei1+U="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-4.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-4.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55544,
-        "QwDYEw=="
+        55544
       ],
-      "ret": "XA0xcA6XjasLvK5pZ4flerywiPGmaEOwBQPBG+aLQs4="
+      "ret": "Hr4wrOBpNwMPVtBjZAWJty+Jzvk5q3KbQcHZjM3gJlg="
     },
     {
       "on": [
         "beacon",
-        6,
-        57454,
-        "QwDYEw=="
+        57454
       ],
-      "ret": "mZZ25W6ql5UBeqz5TTNzA2wSICnNTe7Xgh364pjQd08="
+      "ret": "gmyOSbTaGmxCMhQ7zYs9/x/Po0bHqIHVC1ZqBnXOCb0="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-5.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-5.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55993,
-        "QwDYEw=="
+        55993
       ],
-      "ret": "tdDaGUBU/iA2wNnELOxIdFcRgg3DtY72bzgixLY/08I="
+      "ret": "PjJOglXErOHroeZwrNNQ+b4T10ZPntbh1BmVuepUB3c="
     },
     {
       "on": [
         "beacon",
-        6,
-        57454,
-        "QwDYEw=="
+        57454
       ],
-      "ret": "mZZ25W6ql5UBeqz5TTNzA2wSICnNTe7Xgh364pjQd08="
+      "ret": "gmyOSbTaGmxCMhQ7zYs9/x/Po0bHqIHVC1ZqBnXOCb0="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-6.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-6.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55311,
-        "QwDYEw=="
+        55311
       ],
-      "ret": "iAzK73GhEB7G5hc0p4x3ToeKdCmiZxOQMQ4qoqM23EI="
+      "ret": "AnLBAKFdctxquew2LBNWKdF9KrtJjU0McRnibuMR9ag="
     },
     {
       "on": [
         "beacon",
-        6,
-        57452,
-        "QwDYEw=="
+        57452
       ],
-      "ret": "m1D8Y/Za7+rf/SJ3T0e5aj7YF++jw+I2M++met/ejTU="
+      "ret": "Amh8IHHn3tTnednaD1oITgv6LYlKLDtc49GL0nGGw3w="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-7.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-7.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55155,
-        "QwDYEw=="
+        55155
       ],
-      "ret": "V59SYrrNeG2OZWVPXECa75aWyocVHDeg790GlSIP6lY="
+      "ret": "VPwO8JU+2ZBXkl5/FsaVJDLR0Qqx4ABj4f4Msm6uVkE="
     },
     {
       "on": [
         "beacon",
-        6,
-        57436,
-        "QwDYEw=="
+        57436
       ],
-      "ret": "9H9DSHJNvzN+Ounb2qexY7gHHl2em5ZqWz1C9LDY6+s="
+      "ret": "edQFi6MK1CYQZdcvMsfayjy602EpaBRzmwjTAjuF1i4="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-8.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-8.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        55967,
-        "QwDgCQ=="
+        55967
       ],
-      "ret": "RrvbuNvk5Nl7PZAa8GcmmAOieaF8SENIJQgoboMekWc="
+      "ret": "Gh0m1Gs4g/DI5fxyKGFrxQ0HP0BEj8MpQ+kh2mEMo9E="
     },
     {
       "on": [
         "beacon",
-        6,
-        57489,
-        "QwDgCQ=="
+        57489
       ],
-      "ret": "hN/PGKAyAGaZwV2fCb7pQke/Trt6s06Oqd1NGCrpTOM="
+      "ret": "v4TElQxShwrN3YPJnvROssL83nsyT+lWGkFy8lWcG6g="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-9.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/ProveCommitSector/SysErrOutOfGas/ext-0004-fil_1_storageminer-ProveCommitSector-SysErrOutOfGas-9.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        5,
-        56050,
-        "QwDgCQ=="
+        56050
       ],
-      "ret": "v+yx7qKw0ujPr+8Ki1iQS0kfjpfVoH/gIO4pB+H7d5k="
+      "ret": "NSha/Sh6SOasah8UPUp/QR4iGV66R8M70H29G40pYl8="
     },
     {
       "on": [
         "beacon",
-        6,
-        57504,
-        "QwDgCQ=="
+        57504
       ],
-      "ret": "Shdau/y749gRpV0pr4ZV+KgJChKiJ+fy8hP+8GkDZjM="
+      "ret": "46R+K4pgeHTlnuiC0J74Xb02aS798oCkeqflsX9y7WA="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-1.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-1.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57546,
-        ""
+        57546
       ],
-      "ret": "/uCMf5tuOX/0eNeQIY9J/6EIq99qJWmFZ6cv+lVv31w="
+      "ret": "O4mV9W73yhFrFdb6eBQKTXZtAJY9/bE/2DDppU+P8Kw="
     },
     {
       "on": [
         "beacon",
-        4,
-        57526,
-        "QwDITg=="
+        57526
       ],
-      "ret": "+uRalgXAvb5RnCoeG0IGVQuUp1EXkdLuV6jbYzzMZQk="
+      "ret": "5GAXFdAvYy58x6d64yBsA/KIZoxQO6UExvA/c0BbVag="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-10.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-10.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57517,
-        ""
+        57517
       ],
-      "ret": "X60IfzxjceIVQWTO90qm1TJrMCpah77QhJBLkt92bbU="
+      "ret": "MS76UQ9BRDrGGsIHA70i3yT0H8sHVagVL0ipkD/cTIA="
     },
     {
       "on": [
         "beacon",
-        4,
-        57497,
-        "QwDDKQ=="
+        57497
       ],
-      "ret": "9WDCR96JcauRDH4FEo8M0PAx8E7TUqgwGSAZsL07WAk="
+      "ret": "EQARnz2H6iWeP8SukAJMT2lRzdswXJjJTVemxxO34vc="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-2.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-2.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57544,
-        ""
+        57544
       ],
-      "ret": "f3PZMalKYmcXthTpnUbLq7sL6cjJ3ahIY/TOQelLy1Q="
+      "ret": "Oa8dKVXlwWvKc4t5I9qZg/DNljzgnHQiupEARxIqRp8="
     },
     {
       "on": [
         "beacon",
-        4,
-        57524,
-        "QwCJCg=="
+        57524
       ],
-      "ret": "2p1QRYTKydypgj7pyrlQK+3pB1ow0yV0+ncQ7Qm+Ujw="
+      "ret": "bhxBSo+PDlU9g2ghQWfC9JIuZwWssXbfCd/PwiKRS1I="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-3.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-3.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57535,
-        ""
+        57535
       ],
-      "ret": "SjfyDTFRaBLH4OkQ/mxQB9fyqvXWT8N2ogGSZbkWsEs="
+      "ret": "IVZZKNRApBbalyc5vInaxYqhWt443CK8SK2lk5s4vnU="
     },
     {
       "on": [
         "beacon",
-        4,
-        57515,
-        "QwDvEg=="
+        57515
       ],
-      "ret": "cX8yBtIKQIUg5cSNTSHiK+QBWEt9w5+y2kD7v9YtqzA="
+      "ret": "sbdEGufK+cFDbNWqV6jmUu9O+HCUG9+HuHfM53IceiY="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-4.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-4.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57531,
-        ""
+        57531
       ],
-      "ret": "BPsewNP4/7NmIRPGT3VVbbja8RknIBdTE9yGsl/n7rw="
+      "ret": "kY+54zeTwZtPJkQjvwQgTCEVGX8SmR+ijJyesFhvfxk="
     },
     {
       "on": [
         "beacon",
-        4,
-        57511,
-        "QwDFKQ=="
+        57511
       ],
-      "ret": "YOGMz52raRd9/SCeJmZraqNhe2EW6i77qQzo4sXLQT8="
+      "ret": "jpFUvo6bCJhlgv1+9kRsnTwKnsVshjNFdyHsBasov+8="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-5.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-5.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57543,
-        ""
+        57543
       ],
-      "ret": "wMtci08B9+ivMBkJEmdtwsxK+gJL0Ag4/Ch7GbzsuIE="
+      "ret": "yX2fhFWuymM4f3w3p6++pEY69XrxgMFXKl8BwYpPHQs="
     },
     {
       "on": [
         "beacon",
-        4,
-        57523,
-        "QwC2FA=="
+        57523
       ],
-      "ret": "vgjQXtDquimFQcYyBfrA1fLyTn31L9ie1QnPiWBYJgY="
+      "ret": "O/uhn+KIBa+F+4wZLJcEJ9BM0eTx6zrCrUjczdIjma8="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-6.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-6.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57525,
-        ""
+        57525
       ],
-      "ret": "ENUo5tn0jnsqmeQCUA55P+4qqGU1xHIQMdzVg76L+80="
+      "ret": "XDCQc/pKykrHf7WFsSbXgBngAC7R9FMQEZYKyQ8mBDU="
     },
     {
       "on": [
         "beacon",
-        4,
-        57505,
-        "RACphgE="
+        57505
       ],
-      "ret": "mmTdaljdX9cTquYUo5KZCFbVexpQiwEvjv4IYt6tVgM="
+      "ret": "guIS5fcam6FkK8uXg0KMTkXO95oDGENVOVbfDE7lrNs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-7.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-7.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57521,
-        ""
+        57521
       ],
-      "ret": "0c4Z1Rq3RrzZs3dh2mdYP74ujH4eThCfIS1eYsLMk7o="
+      "ret": "hRNg/9523MYRiok2ZARF2pNrQa+0LR1nXXatNmaWuoo="
     },
     {
       "on": [
         "beacon",
-        4,
-        57501,
-        "QwCqRg=="
+        57501
       ],
-      "ret": "IXIMgwE9AQwN/h1WtQAWiqd59cY17dke5kWJ68cLExQ="
+      "ret": "hHjcF9qBiOWDRtj+Gc6JObOdrK7gd4B+PPmtP7bZMZw="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-8.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-8.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        57515,
-        ""
+        57515
       ],
-      "ret": "WwRwf/Kl2xx8QYGbATUAmo1VYr02PzfMiphdzWzOcLU="
+      "ret": "BajzQrYVUMnSgrNu/FVakvuUuasJdDKuQjXjh4jjUmg="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-9.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/Ok/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-Ok-9.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        57521,
-        ""
+        57521
       ],
-      "ret": "0c4Z1Rq3RrzZs3dh2mdYP74ujH4eThCfIS1eYsLMk7o="
+      "ret": "hRNg/9523MYRiok2ZARF2pNrQa+0LR1nXXatNmaWuoo="
     },
     {
       "on": [
         "beacon",
-        4,
-        57501,
-        "QwCnGg=="
+        57501
       ],
-      "ret": "jyKGL2p6QnJVr35qYi0UQEXrhJwW9XGjXBlGhL7t6iQ="
+      "ret": "hHjcF9qBiOWDRtj+Gc6JObOdrK7gd4B+PPmtP7bZMZw="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-1.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-1.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        57484,
-        ""
+        57484
       ],
-      "ret": "OihTYSWk/jvcjrKDI8xvXS+ynJlBhBrSLqRhxRf3V7w="
+      "ret": "CcYxEQgWlmnSb2f0AdjuCwIzLxWbX+XiN5zcSjrCkf0="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-10.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-10.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        23164,
-        ""
+        23164
       ],
-      "ret": "VDqAuXX2PLfAEPh1kHsD9EgzSgiChZOXzNTbEqAkMb8="
+      "ret": "3qkCULwdv/6rBrnFKUCx00DS/wWXKhPnnS4xmo6x7uY="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-2.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-2.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        56884,
-        ""
+        56884
       ],
-      "ret": "PwpSS8lJ+Yn9X63BYjMVkkkNUYJ/1hj+JvXzt0sYa44="
+      "ret": "KwErBfsgfyq/RFjvOrnah2BqQdaFPEe99A3UAz7+lRs="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-3.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-3.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        56584,
-        ""
+        56584
       ],
-      "ret": "xMG9/ZbEamuIDJugmltHjnFc7Kg2hH5xtPXG/4D2cmA="
+      "ret": "BhT7ra00AJGRrV0hZCVJVdQkYl5DySXOubU99BPbBKk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-4.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-4.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        56224,
-        ""
+        56224
       ],
-      "ret": "7/xBu37sdKc7q0xOcWnwx7OMcAZzJW/qrYPIX1pg7TY="
+      "ret": "lDneOTgdcvCpBpyg6vvZh7tFKdZJaD/EfQquMistppk="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-5.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-5.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        56164,
-        ""
+        56164
       ],
-      "ret": "wrQC5e500r1FOvUJvdw7CKzWXbgEoUCRS1L6G1Sdfy4="
+      "ret": "KV/UEhz1QE6fG1YSm+eLMbCiwmrMv4RkVQZmUQwS5Kw="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-6.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-6.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        53820,
-        ""
+        53820
       ],
-      "ret": "h8pygyz8Md1fiIcVdvAoAC1TeF+rI0INFekVV+8CSBY="
+      "ret": "Ar/dC5oIjVYFwTPKOG8/dbmfdqgZOLePmOXI43f/CYo="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-7.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-7.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        40684,
-        ""
+        40684
       ],
-      "ret": "TNL8jgOb0G+48+Yw3iADBZSCBgXEKwXpnfE7apeWbgs="
+      "ret": "ZbxyGE40BWdNHOl3KmLSW+kOFHBpMguH7uoiLXS9NFs="
     },
     {
       "on": [
         "beacon",
-        4,
-        40664,
-        "QwDPCQ=="
+        40664
       ],
-      "ret": "orlEYjvqadIxSjsDYRw2Lh/XcZ+hagwxxkeunNk+TCI="
+      "ret": "VC25kOXSX8DqxovjJQczXr9BL57UJuE59wHZrDBiP9U="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-8.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-8.json
@@ -29,20 +29,16 @@
     {
       "on": [
         "chain",
-        9,
-        29640,
-        ""
+        29640
       ],
-      "ret": "0v8EDyAyvVXS+74Jd9w0F1c4wSwBK8tlVVI3vM5bjyA="
+      "ret": "BPlDbKKTyXX3tRq1hv9ajuFbEPSD6O6K7ZBm2LJa6oo="
     },
     {
       "on": [
         "beacon",
-        4,
-        29620,
-        "RACOgAE="
+        29620
       ],
-      "ret": "29bmoB87i9I4s/zx+lv4oILR/kkb+5jap/sN0tlhTqY="
+      "ret": "oC3QbpP8+4RG2EZE0s6v+p8M68OEuY27UZlqZ02b82U="
     }
   ],
   "preconditions": {

--- a/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-9.json
+++ b/corpus/extracted/0004-coverage-boost/fil_1_storageminer/SubmitWindowedPoSt/SysErrOutOfGas/ext-0004-fil_1_storageminer-SubmitWindowedPoSt-SysErrOutOfGas-9.json
@@ -29,11 +29,9 @@
     {
       "on": [
         "chain",
-        9,
-        25864,
-        ""
+        25864
       ],
-      "ret": "uEj7SFOAoZ4nwzqKInBwX5rgxMEYhRxxYDCx0j/xTnY="
+      "ret": "JULWxDy0L3ifscnio/M1oV2OCjOUFvKoinqgb/8XOU0="
     }
   ],
   "preconditions": {

--- a/schema.json
+++ b/schema.json
@@ -111,9 +111,7 @@
                 "enum": [
                   "chain",
                   "beacon"
-                ]
-              },
-              {
+              }
                 "title": "domain separation tag",
                 "type": "number"
               },

--- a/schema/schema_randomness.go
+++ b/schema/schema_randomness.go
@@ -14,18 +14,14 @@ const (
 // This encodes to JSON as an array. See godocs on the Randomness type for
 // more info.
 type RandomnessRule struct {
-	Kind                RandomnessKind
-	DomainSeparationTag int64
-	Epoch               int64
-	Entropy             Base64EncodedBytes
+	Kind  RandomnessKind
+	Epoch int64
 }
 
 func (rm RandomnessRule) MarshalJSON() ([]byte, error) {
 	array := [4]interface{}{
 		rm.Kind,
-		rm.DomainSeparationTag,
 		rm.Epoch,
-		rm.Entropy,
 	}
 	return json.Marshal(array)
 }
@@ -42,13 +38,7 @@ func (rm *RandomnessRule) UnmarshalJSON(v []byte) error {
 	if err = json.Unmarshal(arr[0], &out.Kind); err != nil {
 		return err
 	}
-	if err = json.Unmarshal(arr[1], &out.DomainSeparationTag); err != nil {
-		return err
-	}
-	if err = json.Unmarshal(arr[2], &out.Epoch); err != nil {
-		return err
-	}
-	if err = json.Unmarshal(arr[3], &out.Entropy); err != nil {
+	if err = json.Unmarshal(arr[1], &out.Epoch); err != nil {
 		return err
 	}
 	*rm = out
@@ -60,10 +50,10 @@ func (rm *RandomnessRule) UnmarshalJSON(v []byte) error {
 //
 // The json serialized form is:
 //
-//  "randomness": [
-//    { "on": ["beacon", 12, 49327, "yxpTbzLhr4uaj7bK0Hl4Vw=="], "ret": "iKyZ2N83N8IoiK2tNJ/H9g==" },
-//    { "on": ["chain", 8, 61002, "aacQWICNcMJWtuwTnU+1Hg=="], "ret": "M6HqmihwZ5fXcbQQHhbtsg==" }
-//  ]
+//	"randomness": [
+//	  { "on": ["beacon", 12, 49327, "yxpTbzLhr4uaj7bK0Hl4Vw=="], "ret": "iKyZ2N83N8IoiK2tNJ/H9g==" },
+//	  { "on": ["chain", 8, 61002, "aacQWICNcMJWtuwTnU+1Hg=="], "ret": "M6HqmihwZ5fXcbQQHhbtsg==" }
+//	]
 //
 // The four positional values of the `on` array field are:
 //


### PR DESCRIPTION
Integrates changes in https://github.com/filecoin-project/lotus/pull/11167, that arise from FVM changes in https://github.com/filecoin-project/ref-fvm/issues/1277.

This is gonna be hard to land, because of the complex dependency on Lotus (which is very stale). I'm just depending directly on this commit in Lotus for now.